### PR TITLE
Enhancement: Add CSV standard comment marker

### DIFF
--- a/app/tandem/SEAS.cpp
+++ b/app/tandem/SEAS.cpp
@@ -77,29 +77,33 @@ auto add_writers(Config const& cfg, LocalSimplexMesh<DomainDimension> const& mes
         }
     }
     if (cfg.fault_probe_output) {
+        auto const& oc = *cfg.fault_probe_output;
         monitor.add_writer(std::make_unique<seas::FaultProbeWriter<DomainDimension>>(
-            cfg.fault_probe_output->prefix, cfg.fault_probe_output->probes,
-            cfg.fault_probe_output->make_adaptive_output_interval(), mesh, cl, fault_map, comm));
+            oc.prefix, oc.make_writer(), oc.probes, oc.make_adaptive_output_interval(), mesh, cl,
+            fault_map, comm));
     }
     if (cfg.domain_probe_output) {
+        auto const& oc = *cfg.domain_probe_output;
         monitor.add_writer(std::make_unique<seas::DomainProbeWriter<DomainDimension>>(
-            cfg.domain_probe_output->prefix, cfg.domain_probe_output->probes,
-            cfg.domain_probe_output->make_adaptive_output_interval(), mesh, cl, comm));
+            oc.prefix, oc.make_writer(), oc.probes, oc.make_adaptive_output_interval(), mesh, cl,
+            comm));
     }
     if (cfg.fault_output) {
+        auto const& oc = *cfg.fault_output;
         monitor.add_writer(std::make_unique<seas::FaultWriter<DomainDimension>>(
-            cfg.fault_output->prefix, cfg.fault_output->make_adaptive_output_interval(), mesh, cl,
-            PolynomialDegree, fault_map, comm));
+            oc.prefix, oc.make_adaptive_output_interval(), mesh, cl, PolynomialDegree, fault_map,
+            comm));
     }
     if (cfg.fault_scalar_output) {
+        auto const& oc = *cfg.fault_scalar_output;
         monitor.add_writer(std::make_unique<seas::FaultScalarWriter>(
-            cfg.fault_scalar_output->prefix,
-            cfg.fault_scalar_output->make_adaptive_output_interval(), comm));
+            oc.prefix, oc.make_writer(), oc.make_adaptive_output_interval(), comm));
     }
     if (cfg.domain_output) {
+        auto const& oc = *cfg.domain_output;
         monitor.add_writer(std::make_unique<seas::DomainWriter<DomainDimension>>(
-            cfg.domain_output->prefix, cfg.domain_output->make_adaptive_output_interval(), mesh, cl,
-            PolynomialDegree, cfg.domain_output->jacobian, comm));
+            oc.prefix, oc.make_adaptive_output_interval(), mesh, cl, PolynomialDegree, oc.jacobian,
+            comm));
     }
 }
 

--- a/src/io/BoundaryProbeWriter.h
+++ b/src/io/BoundaryProbeWriter.h
@@ -5,13 +5,13 @@
 #include "form/FiniteElementFunction.h"
 #include "geometry/Curvilinear.h"
 #include "io/Probe.h"
+#include "io/TableWriter.h"
 #include "mesh/LocalSimplexMesh.h"
 
 #include <mneme/span.hpp>
 #include <mpi.h>
 
 #include <cstddef>
-#include <fstream>
 #include <memory>
 #include <string>
 #include <utility>
@@ -21,9 +21,10 @@ namespace tndm {
 
 template <std::size_t D> class BoundaryProbeWriter {
 public:
-    BoundaryProbeWriter(std::string_view prefix, std::vector<Probe<D>> const& probes,
-                        LocalSimplexMesh<D> const& mesh, std::shared_ptr<Curvilinear<D>> cl,
-                        BoundaryMap const& bnd_map, MPI_Comm comm);
+    BoundaryProbeWriter(std::string_view prefix, std::unique_ptr<TableWriter> table_writer,
+                        std::vector<Probe<D>> const& probes, LocalSimplexMesh<D> const& mesh,
+                        std::shared_ptr<Curvilinear<D>> cl, BoundaryMap const& bnd_map,
+                        MPI_Comm comm);
 
     void write(double time, mneme::span<FiniteElementFunction<D - 1>> functions) const;
 
@@ -41,9 +42,10 @@ private:
         std::array<double, D> x;
     };
 
-    void write_header(std::ofstream& file, ProbeMeta const& p,
+    void write_header(ProbeMeta const& p,
                       mneme::span<FiniteElementFunction<D - 1>> functions) const;
 
+    std::unique_ptr<TableWriter> out_;
     std::vector<std::size_t> bndNos_;
     std::vector<ProbeMeta> probes_;
 };

--- a/src/io/CSVWriter.h
+++ b/src/io/CSVWriter.h
@@ -1,0 +1,82 @@
+#ifndef CSVWRITER_20211118_H
+#define CSVWRITER_20211118_H
+
+#include "TableWriter.h"
+
+#include <fstream>
+#include <iomanip>
+#include <ios>
+#include <string>
+#include <string_view>
+
+namespace tndm {
+
+class CSVWriter : public TableWriter {
+protected:
+    template <typename T> void add(T const& t) { out_ << t << sep_; }
+
+    std::ofstream out_;
+
+private:
+    char sep_ = ' ';
+
+public:
+    CSVWriter(char separator = ',', int precision = 15) : out_{}, sep_(separator) {
+        out_ << std::scientific;
+        set_precision(precision);
+    }
+    virtual ~CSVWriter() {}
+
+    inline void set_separator(char separator) { sep_ = separator; }
+    inline void set_precision(int precision) { out_ << std::setprecision(precision); }
+
+    inline std::string_view default_extension() const override { return ".csv"; }
+    inline void open(std::string const& file_name, bool append) override {
+        auto openmode = std::ios::out;
+        if (append) {
+            /* We use ios::ate instead of ios::app, because with ios::app we cannot use
+             * seekp. ios::in needs to be added for some reason because otherwise the
+             * file is overwritten.
+             */
+            openmode |= std::ios::ate | std::ios::in;
+        }
+        out_.open(file_name, openmode);
+    }
+    inline void close() override {
+        out_.close();
+        out_.clear();
+    }
+    inline void add_title(std::string_view title) override { out_ << "# " << title << std::endl; }
+    inline void endrow() override {
+        out_.seekp(-1, std::ios::cur);
+        out_ << std::endl;
+    }
+    inline void beginheader() override {}
+    inline void endheader() override { endrow(); }
+    inline void flush() override { out_.flush(); }
+
+    inline TableWriter& operator<<(int value) override {
+        add(value);
+        return *this;
+    }
+    inline TableWriter& operator<<(unsigned int value) override {
+        add(value);
+        return *this;
+    }
+    inline TableWriter& operator<<(float value) override {
+        add(value);
+        return *this;
+    }
+    inline TableWriter& operator<<(double value) override {
+        add(value);
+        return *this;
+    }
+    inline TableWriter& operator<<(std::string_view value) override {
+        out_ << "\"" << value << "\"" << sep_;
+        return *this;
+    }
+};
+
+} // namespace tndm
+
+#endif // CSVWRITER_20211118_H

--- a/src/io/ProbeWriter.cpp
+++ b/src/io/ProbeWriter.cpp
@@ -56,13 +56,13 @@ ProbeWriter<D>::ProbeWriter(std::string_view prefix, std::vector<Probe<D>> const
 template <std::size_t D>
 void ProbeWriter<D>::write_header(std::ofstream& file, ProbeMeta const& p,
                                   mneme::span<FiniteElementFunction<D>> functions) const {
-    file << "TITLE = \"Station " << p.name << " (x = [";
+    file << "# TITLE = \"Station " << p.name << " (x = [";
     for (std::size_t d = 0; d < D; ++d) {
         file << p.x[d] << ", ";
     }
     file.seekp(-2, std::ios::cur);
     file << "])\"" << std::endl;
-    file << "VARIABLES = \"Time\"";
+    file << "# VARIABLES = \"Time\"";
     for (auto const& function : functions) {
         for (std::size_t q = 0; q < function.numQuantities(); ++q) {
             file << ",\"" << function.name(q) << "\"";

--- a/src/io/ProbeWriter.cpp
+++ b/src/io/ProbeWriter.cpp
@@ -3,18 +3,18 @@
 #include "geometry/PointLocator.h"
 #include "io/ProbeWriterUtil.h"
 
-#include <iomanip>
-#include <ios>
 #include <mpi.h>
+#include <sstream>
 #include <unordered_map>
 #include <unordered_set>
 
 namespace tndm {
 
 template <std::size_t D>
-ProbeWriter<D>::ProbeWriter(std::string_view prefix, std::vector<Probe<D>> const& probes,
-                            LocalSimplexMesh<D> const& mesh, std::shared_ptr<Curvilinear<D>> cl,
-                            MPI_Comm comm) {
+ProbeWriter<D>::ProbeWriter(std::string_view prefix, std::unique_ptr<TableWriter> table_writer,
+                            std::vector<Probe<D>> const& probes, LocalSimplexMesh<D> const& mesh,
+                            std::shared_ptr<Curvilinear<D>> cl, MPI_Comm comm)
+    : out_(std::move(table_writer)) {
     auto pl = PointLocator<D>(cl);
     auto range = Range<std::size_t>(0, mesh.elements().localSize());
 
@@ -47,53 +47,54 @@ ProbeWriter<D>::ProbeWriter(std::string_view prefix, std::vector<Probe<D>> const
     probes_.reserve(located_probes.size());
     for (auto const& p : located_probes) {
         auto file_name = std::string(prefix);
-        file_name += probes[p.first].name + ".dat";
+        file_name += probes[p.first].name;
+        file_name += out_->default_extension();
         probes_.emplace_back(ProbeMeta{probes[p.first].name, file_name, elNo2OutNo[p.second.no],
                                        p.second.xi, p.second.x});
     }
 }
 
 template <std::size_t D>
-void ProbeWriter<D>::write_header(std::ofstream& file, ProbeMeta const& p,
+void ProbeWriter<D>::write_header(ProbeMeta const& p,
                                   mneme::span<FiniteElementFunction<D>> functions) const {
-    file << "# TITLE = \"Station " << p.name << " (x = [";
+    std::stringstream s;
+    s << "Station " << p.name << " (x = [";
     for (std::size_t d = 0; d < D; ++d) {
-        file << p.x[d] << ", ";
+        s << p.x[d] << ", ";
     }
-    file.seekp(-2, std::ios::cur);
-    file << "])\"" << std::endl;
-    file << "# VARIABLES = \"Time\"";
+    s.seekp(-2, std::ios::cur);
+    s << "])";
+    out_->add_title(s.str());
+    *out_ << beginheader << "Time";
     for (auto const& function : functions) {
         for (std::size_t q = 0; q < function.numQuantities(); ++q) {
-            file << ",\"" << function.name(q) << "\"";
+            *out_ << function.name(q);
         }
     }
-    file << std::endl;
+    *out_ << endheader;
 }
 
 template <std::size_t D>
 void ProbeWriter<D>::write(double time, mneme::span<FiniteElementFunction<D>> functions) const {
     for (auto const& probe : probes_) {
-        std::ofstream file;
         if (time <= 0.0) {
-            file.open(probe.file_name, std::ios::out);
-            write_header(file, probe, functions);
+            out_->open(probe.file_name, false);
+            write_header(probe, functions);
         } else {
-            file.open(probe.file_name, std::ios::app);
+            out_->open(probe.file_name, true);
         }
 
-        file << std::scientific << std::setprecision(15);
-        file << time;
+        *out_ << time;
         for (auto const& function : functions) {
             auto result = Managed<Matrix<double>>(function.mapResultInfo(1));
             auto E = function.evaluationMatrix({probe.xi});
             function.map(probe.no, E, result);
             for (std::size_t p = 0; p < function.numQuantities(); ++p) {
-                file << " " << result(0, p);
+                *out_ << result(0, p);
             }
         }
-        file << std::endl;
-        file.close();
+        *out_ << endrow;
+        out_->close();
     }
 }
 

--- a/src/io/ProbeWriter.h
+++ b/src/io/ProbeWriter.h
@@ -5,13 +5,13 @@
 #include "form/FiniteElementFunction.h"
 #include "geometry/Curvilinear.h"
 #include "io/Probe.h"
+#include "io/TableWriter.h"
 #include "mesh/LocalSimplexMesh.h"
 
 #include <mneme/span.hpp>
 #include <mpi.h>
 
 #include <cstddef>
-#include <fstream>
 #include <memory>
 #include <string>
 #include <utility>
@@ -21,8 +21,9 @@ namespace tndm {
 
 template <std::size_t D> class ProbeWriter {
 public:
-    ProbeWriter(std::string_view prefix, std::vector<Probe<D>> const& probes,
-                LocalSimplexMesh<D> const& mesh, std::shared_ptr<Curvilinear<D>> cl, MPI_Comm comm);
+    ProbeWriter(std::string_view prefix, std::unique_ptr<TableWriter> table_writer,
+                std::vector<Probe<D>> const& probes, LocalSimplexMesh<D> const& mesh,
+                std::shared_ptr<Curvilinear<D>> cl, MPI_Comm comm);
 
     void write(double time, mneme::span<FiniteElementFunction<D>> functions) const;
 
@@ -41,9 +42,9 @@ private:
         std::array<double, D> x;
     };
 
-    void write_header(std::ofstream& file, ProbeMeta const& p,
-                      mneme::span<FiniteElementFunction<D>> functions) const;
+    void write_header(ProbeMeta const& p, mneme::span<FiniteElementFunction<D>> functions) const;
 
+    std::unique_ptr<TableWriter> out_;
     std::vector<std::size_t> elNos_;
     std::vector<ProbeMeta> probes_;
 };

--- a/src/io/ScalarWriter.cpp
+++ b/src/io/ScalarWriter.cpp
@@ -5,31 +5,29 @@
 
 namespace tndm {
 
-void ScalarWriter::write_header(std::ofstream& file) const {
-    file << "TITLE = \"Scalar output\"" << std::endl;
-    file << "VARIABLES = \"Time\"";
+void ScalarWriter::write_header() const {
+    out_->add_title("Scalar output");
+    *out_ << beginheader << "Time";
     for (auto variable_name : variable_names_) {
-        file << ",\"" << variable_name << "\"";
+        *out_ << variable_name;
     }
-    file << std::endl;
+    *out_ << endheader;
 }
 
 void ScalarWriter::write(double time, mneme::span<double> scalars) const {
-    std::ofstream file;
     if (time <= 0.0) {
-        file.open(file_name_, std::ios::out);
-        write_header(file);
+        out_->open(file_name_, false);
+        write_header();
     } else {
-        file.open(file_name_, std::ios::app);
+        out_->open(file_name_, true);
     }
 
-    file << std::scientific << std::setprecision(15);
-    file << time;
+    *out_ << time;
     for (auto scalar : scalars) {
-        file << " " << scalar;
+        *out_ << scalar;
     }
-    file << std::endl;
-    file.close();
+    *out_ << endrow;
+    out_->close();
 }
 
 } // namespace tndm

--- a/src/io/ScalarWriter.h
+++ b/src/io/ScalarWriter.h
@@ -1,10 +1,12 @@
 #ifndef SCALARWRITER_20210721_H
 #define SCALARWRITER_20210721_H
 
+#include "TableWriter.h"
+
 #include <mneme/span.hpp>
 
 #include <cstddef>
-#include <fstream>
+#include <memory>
 #include <string>
 #include <utility>
 #include <vector>
@@ -13,17 +15,20 @@ namespace tndm {
 
 class ScalarWriter {
 public:
-    ScalarWriter(std::string_view prefix, std::vector<std::string> variable_names)
-        : file_name_(prefix), variable_names_(std::move(variable_names)) {
-        file_name_ += ".dat";
+    ScalarWriter(std::string_view prefix, std::unique_ptr<TableWriter> table_writer,
+                 std::vector<std::string> variable_names)
+        : file_name_(prefix), out_(std::move(table_writer)),
+          variable_names_(std::move(variable_names)) {
+        file_name_ += out_->default_extension();
     }
 
     void write(double time, mneme::span<double> scalars) const;
 
 private:
-    void write_header(std::ofstream& file) const;
+    void write_header() const;
 
     std::string file_name_;
+    std::unique_ptr<TableWriter> out_;
     std::vector<std::string> variable_names_;
 };
 

--- a/src/io/TableWriter.h
+++ b/src/io/TableWriter.h
@@ -1,0 +1,47 @@
+#ifndef TABLEWRITER_20211118_H
+#define TABLEWRITER_20211118_H
+
+#include <cstddef>
+#include <string_view>
+
+namespace tndm {
+
+class TableWriter {
+public:
+    virtual ~TableWriter() {}
+
+    virtual std::string_view default_extension() const = 0;
+    virtual void open(std::string const& file_name, bool append) = 0;
+    virtual void close() = 0;
+    virtual void add_title(std::string_view title) = 0;
+    virtual void endrow() = 0;
+    virtual void beginheader() = 0;
+    virtual void endheader() = 0;
+    virtual void flush() = 0;
+
+    virtual TableWriter& operator<<(int value) = 0;
+    virtual TableWriter& operator<<(unsigned int value) = 0;
+    virtual TableWriter& operator<<(float value) = 0;
+    virtual TableWriter& operator<<(double value) = 0;
+    virtual TableWriter& operator<<(std::string_view value) = 0;
+    virtual TableWriter& operator<<(TableWriter& (*func)(TableWriter&)) { return func(*this); }
+};
+
+inline TableWriter& endrow(TableWriter& writer) {
+    writer.endrow();
+    return writer;
+}
+
+inline TableWriter& beginheader(TableWriter& writer) {
+    writer.beginheader();
+    return writer;
+}
+
+inline TableWriter& endheader(TableWriter& writer) {
+    writer.endheader();
+    return writer;
+}
+
+} // namespace tndm
+
+#endif // TABLEWRITER_20211118_H

--- a/src/io/TecplotWriter.h
+++ b/src/io/TecplotWriter.h
@@ -1,0 +1,31 @@
+#ifndef TECPLOTWRITER_20211118_H
+#define TECPLOTWRITER_20211118_H
+
+#include "CSVWriter.h"
+
+#include <string_view>
+
+namespace tndm {
+
+class TecplotWriter : public CSVWriter {
+public:
+    TecplotWriter(int precision = 15) : CSVWriter(' ', precision) {}
+    virtual ~TecplotWriter() {}
+
+    inline std::string_view default_extension() const override { return ".dat"; }
+    inline void add_title(std::string_view title) override {
+        out_ << "TITLE = \"" << title << "\"" << std::endl;
+    }
+    inline void beginheader() override {
+        out_ << "VARIABLES = ";
+        set_separator(',');
+    }
+    inline void endheader() override {
+        endrow();
+        set_separator(' ');
+    }
+};
+
+} // namespace tndm
+
+#endif // TECPLOTWRITER_20211118_H


### PR DESCRIPTION
Marking header lines with a `#` will permit trivial parsing of these output files with standard CSV headers which support white space delimiters.
Note: Existing parsers currently in use may break.