### PR TITLE
Gather vtk output to reduce number of files

### DIFF
--- a/app/check-bc.cpp
+++ b/app/check-bc.cpp
@@ -84,7 +84,7 @@ void write_bcs(LocalSimplexMesh<D> const& mesh, unsigned N, std::vector<std::siz
     auto adapter = CurvilinearBoundaryVTUAdapter(mesh, cl, fctNos);
     auto writer = VTUWriter<D - 1u>(N, true, MPI_COMM_WORLD);
 
-    auto piece = writer.addPiece(adapter);
+    auto& piece = writer.addPiece(adapter);
     piece.addCellData("bc", bcs.data(), bcs.size());
     writer.write(prefix);
 }

--- a/app/static.cpp
+++ b/app/static.cpp
@@ -210,7 +210,7 @@ void static_problem(LocalSimplexMesh<DomainDimension> const& mesh, Scenario cons
         auto coeffs = dgop.params();
         VTUWriter<DomainDimension> writer(PolynomialDegree, true, PETSC_COMM_WORLD);
         auto adapter = CurvilinearVTUAdapter(cl, dgop.num_local_elements());
-        auto piece = writer.addPiece(adapter);
+        auto& piece = writer.addPiece(adapter);
         piece.addPointData(numeric);
         piece.addJacobianData(numeric, adapter);
         piece.addPointData(coeffs);

--- a/app/tandem/Writer.h
+++ b/app/tandem/Writer.h
@@ -132,7 +132,7 @@ public:
 
         auto writer = VTUWriter<D - 1u>(degree_, true, comm_);
         writer.addFieldData("time", &time, 1);
-        auto piece = writer.addPiece(adapter_);
+        auto& piece = writer.addPiece(adapter_);
         for (auto const& fun : data) {
             piece.addPointData(fun);
         }
@@ -146,7 +146,7 @@ public:
 
     void write_static(mneme::span<FiniteElementFunction<D - 1u>> data) override {
         auto writer = VTUWriter<D - 1u>(degree_, true, comm_);
-        auto piece = writer.addPiece(adapter_);
+        auto& piece = writer.addPiece(adapter_);
         for (auto const& fun : data) {
             piece.addPointData(fun);
         }
@@ -197,7 +197,7 @@ public:
 
         auto writer = VTUWriter<D>(degree_, true, comm_);
         writer.addFieldData("time", &time, 1);
-        auto piece = writer.addPiece(adapter_);
+        auto& piece = writer.addPiece(adapter_);
         for (auto const& fun : data) {
             piece.addPointData(fun);
             if (jacobian_) {
@@ -214,7 +214,7 @@ public:
 
     void write_static(mneme::span<FiniteElementFunction<D>> data) override {
         auto writer = VTUWriter<D>(degree_, true, comm_);
-        auto piece = writer.addPiece(adapter_);
+        auto& piece = writer.addPiece(adapter_);
         for (auto const& fun : data) {
             piece.addPointData(fun);
         }

--- a/app/test-mesh.cpp
+++ b/app/test-mesh.cpp
@@ -64,7 +64,7 @@ void writeMesh(std::string const& baseName, GenMesh<D> const& meshGen, Fun trans
     VTUWriter<D> writer(degree);
     auto adapter = CurvilinearVTUAdapter(
         std::make_shared<Curvilinear<D>>(*mesh, *transform, degree), mesh->elements().localSize());
-    auto piece = writer.addPiece(adapter);
+    auto& piece = writer.addPiece(adapter);
     piece.addCellData("BC", bc);
     piece.addCellData("shared", shared);
     writer.write(baseName);

--- a/src/io/DataType.h
+++ b/src/io/DataType.h
@@ -9,10 +9,11 @@
 
 namespace tndm {
 
-enum class BaseType { Float, Int, UInt };
+enum class BaseType { Float, Int, UInt, None };
 
 class DataType {
 public:
+    DataType() : type_(BaseType::None), bytes_(0) {}
     DataType(BaseType type, unsigned bytes) : type_(type), bytes_(bytes) {}
 
     template <typename T, std::enable_if_t<std::is_floating_point_v<T>, int> = 0>
@@ -38,6 +39,9 @@ public:
             break;
         case BaseType::UInt:
             s << "UInt";
+            break;
+        case BaseType::None:
+            s << "None";
             break;
         default:
             break;

--- a/src/io/VTUWriter.cpp
+++ b/src/io/VTUWriter.cpp
@@ -22,7 +22,63 @@ using tinyxml2::XMLPrinter;
 
 namespace tndm {
 
-template <std::size_t D> int32_t VTUWriter<D>::VTKType(bool linear) {
+uint64_t VTKDataArray::make_xml(tinyxml2::XMLElement* parent, uint64_t offset) const {
+    auto da = parent->InsertNewChildElement("DataArray");
+    da->SetAttribute("type", type_.vtkIdentifier().c_str());
+    da->SetAttribute("Name", name_.c_str());
+    da->SetAttribute("NumberOfComponents", static_cast<uint64_t>(num_components_));
+    da->SetAttribute("format", "appended");
+    da->SetAttribute("offset", offset);
+    return offset + appended_.size();
+}
+
+void VTKDataArray::write_appended(FILE* fp) const {
+    std::fwrite(appended_.data(), sizeof(unsigned char), appended_.size(), fp);
+}
+
+void VTKDataArray::make_appended(unsigned char const* data, header_t size, bool zlibCompress) {
+    unsigned char dummy_data = 0;
+    if (data == nullptr) {
+        if (size == 0) {
+            data = &dummy_data;
+        } else {
+            throw std::logic_error("VTKDataArray got nullptr but dataSize != 0");
+        }
+    }
+
+    if (zlibCompress) {
+        struct {
+            header_t blocks;
+            header_t blockSize;
+            header_t lastBlockSize;
+            header_t compressedBlocksizes;
+        } header{1, size, size, 0};
+        auto destLen = compressBound(size);
+        appended_ = std::vector<unsigned char>(sizeof(header) + destLen);
+        unsigned char* app = appended_.data();
+        compress(app + sizeof(header), &destLen, data, size);
+        header.compressedBlocksizes = destLen;
+        memcpy(app, &header, sizeof(header));
+        appended_.resize(sizeof(header) + destLen);
+    } else {
+        appended_ = std::vector<unsigned char>(sizeof(size) + size);
+        unsigned char* app = appended_.data();
+        memcpy(app, &size, sizeof(size));
+        app += sizeof(size);
+        memcpy(app, data, size);
+    }
+}
+
+template <std::size_t D>
+VTUWriter<D>::VTUWriter(unsigned degree, bool zlibCompress, MPI_Comm comm)
+    : refNodes_(EquidistantNodesFactory<D>(NumberingConvention::VTK)(degree)),
+      zlibCompress_(zlibCompress), comm_(comm) {
+    MPI_Comm_split_type(comm_, MPI_COMM_TYPE_SHARED, 0, MPI_INFO_NULL, &group_comm_);
+}
+
+template <std::size_t D> VTUWriter<D>::~VTUWriter() { MPI_Comm_free(&group_comm_); }
+
+template <std::size_t D> int32_t VTUPiece<D>::VTKType(bool linear) {
     if constexpr (D == 1u) {
         if (linear) {
             return 3; // VTK_LINE
@@ -42,19 +98,29 @@ template <std::size_t D> int32_t VTUWriter<D>::VTKType(bool linear) {
     return 0; // VTK_EMPTY_CELL
 };
 
-template <std::size_t D> VTUPiece<D> VTUWriter<D>::addPiece(VTUAdapter<D>& adapter) {
-    auto pointsPerElement = refNodes_.size();
+template <std::size_t D> VTUPiece<D>& VTUWriter<D>::addPiece(VTUAdapter<D>& adapter) {
+    auto& piece = pieces_.emplace_back(VTUPiece<D>(adapter, refNodes_, zlibCompress_, group_comm_));
 
-    std::size_t numElements = adapter.numElements();
+    int rank;
+    MPI_Comm_rank(comm_, &rank);
+    auto partition = std::vector<int32_t>(piece.numElements(), rank);
+    piece.addCellData("partition", partition);
+
+    return piece;
+}
+
+template <std::size_t D>
+VTUPiece<D>::VTUPiece(VTUAdapter<D>& adapter, std::vector<std::array<double, D>> const& refNodes,
+                      bool zlibCompress, MPI_Comm group_comm)
+    : refNodes_(&refNodes), zlibCompress_(zlibCompress), group_comm_(group_comm) {
+    auto pointsPerElement = refNodes_->size();
+    num_elements_ = adapter.numElements();
     std::size_t pointDim = adapter.pointDim();
-    adapter.setRefNodes(refNodes_);
-    auto piece = doc_.RootElement()->InsertNewChildElement("Piece");
-    piece->SetAttribute("NumberOfPoints", static_cast<uint64_t>(pointsPerElement * numElements));
-    piece->SetAttribute("NumberOfCells", static_cast<uint64_t>(numElements));
+
+    adapter.setRefNodes(*refNodes_);
     {
-        auto points = piece->InsertNewChildElement("Points");
-        auto vertices = std::vector<double>(numElements * pointsPerElement * PointDim);
-        for (std::size_t elNo = 0; elNo < numElements; ++elNo) {
+        auto vertices = std::vector<double>(num_elements_ * pointsPerElement * PointDim);
+        for (std::size_t elNo = 0; elNo < num_elements_; ++elNo) {
             auto firstVertex = &vertices[elNo * pointsPerElement * PointDim];
             auto result = Matrix<double>(firstVertex, pointDim, pointsPerElement);
             adapter.map(elNo, result);
@@ -70,46 +136,35 @@ template <std::size_t D> VTUPiece<D> VTUWriter<D>::addPiece(VTUAdapter<D>& adapt
                 }
             }
         }
-        addDataArray(points, "Points", PointDim, vertices);
+        auto gathered_points = gather(vertices.data(), vertices.size());
+        points_ = VTKDataArray("Points", PointDim, gathered_points, zlibCompress_);
     }
 
-    auto cells = piece->InsertNewChildElement("Cells");
-    {
-        auto connectivity = std::vector<int32_t>(numElements * pointsPerElement);
-        std::iota(connectivity.begin(), connectivity.end(), 0);
-        addDataArray(cells, "connectivity", 1, connectivity);
+    using size_type = decltype(num_elements_);
+    gathered_num_elements_ = 0;
+    MPI_Reduce(&num_elements_, &gathered_num_elements_, 1, mpi_type_t<size_type>(), MPI_SUM, 0,
+               group_comm_);
 
-        auto offsets = std::vector<int32_t>(numElements);
+    {
+        auto connectivity = std::vector<int32_t>(gathered_num_elements_ * pointsPerElement);
+        std::iota(connectivity.begin(), connectivity.end(), 0);
+        connectivity_ = VTKDataArray("connectivity", 1, connectivity, zlibCompress_);
+
+        auto offsets = std::vector<int32_t>(gathered_num_elements_);
         std::generate(offsets.begin(), offsets.end(),
                       [&pointsPerElement, n = 1]() mutable { return pointsPerElement * n++; });
-        addDataArray(cells, "offsets", 1, offsets);
+        offsets_ = VTKDataArray("offsets", 1, offsets, zlibCompress_);
 
-        auto vtkType = VTKType(refNodes_.size() == (D + 1ul));
-        auto types = std::vector<uint8_t>(numElements, vtkType);
-        addDataArray(cells, "types", 1, types);
+        auto vtkType = VTKType(refNodes_->size() == (D + 1ul));
+        auto types = std::vector<uint8_t>(gathered_num_elements_, vtkType);
+        types_ = VTKDataArray("types", 1, types, zlibCompress_);
     }
-
-    auto vtupiece = VTUPiece<D>(piece, *this);
-    int rank;
-    MPI_Comm_rank(comm_, &rank);
-    auto partition = std::vector<int32_t>(numElements, rank);
-    vtupiece.addCellData("partition", partition);
-    return vtupiece;
-}
-
-template <std::size_t D> tinyxml2::XMLElement* VTUPiece<D>::getPointDataRoot() {
-    XMLElement* pdata = piece_->LastChildElement("PointData");
-    if (!pdata) {
-        pdata = piece_->InsertNewChildElement("PointData");
-    }
-    return pdata;
 }
 
 template <std::size_t D> void VTUPiece<D>::addPointData(FiniteElementFunction<D> const& function) {
-    auto pointsPerElement = writer_.refNodes().size();
-    XMLElement* pdata = getPointDataRoot();
+    auto pointsPerElement = refNodes_->size();
 
-    auto E = function.evaluationMatrix(writer_.refNodes());
+    auto E = function.evaluationMatrix(*refNodes_);
     auto data = Managed<Tensor<double, 3u>>(pointsPerElement, function.numElements(),
                                             function.numQuantities());
     auto result = Managed(function.mapResultInfo(pointsPerElement));
@@ -126,19 +181,20 @@ template <std::size_t D> void VTUPiece<D>::addPointData(FiniteElementFunction<D>
         if (function.numElements() > 0) {
             data_ptr = &data(0, 0, p);
         }
-        writer_.addDataArray(pdata, function.name(p), 1, data_ptr,
-                             pointsPerElement * function.numElements());
+        point_data_.emplace_back(VTKDataArray(
+            function.name(p), 1, gather(data_ptr, pointsPerElement * function.numElements()),
+            zlibCompress_));
     }
 }
 
 template <std::size_t D>
 void VTUPiece<D>::addJacobianData(FiniteElementFunction<D> const& function,
-                                  VTUAdapter<D> const& adapter) {
-    auto pointsPerElement = writer_.refNodes().size();
-    XMLElement* pdata = getPointDataRoot();
+                                  VTUAdapter<D>& adapter) {
+    auto pointsPerElement = refNodes_->size();
+    adapter.setRefNodes(*refNodes_);
 
     auto scratch = Scratch<double>(adapter.scratch_mem_size());
-    auto Dxi = function.gradientEvaluationTensor(writer_.refNodes());
+    auto Dxi = function.gradientEvaluationTensor(*refNodes_);
     auto data = Managed<Tensor<double, 3u>>(pointsPerElement, function.numElements(),
                                             D * function.numQuantities());
     auto jInvAtP = Managed(adapter.jacobianResultInfo());
@@ -163,22 +219,105 @@ void VTUPiece<D>::addJacobianData(FiniteElementFunction<D> const& function,
             }
             std::stringstream s;
             s << "d" << function.name(p) << "_d" << d;
-            writer_.addDataArray(pdata, s.str(), 1, data_ptr,
-                                 pointsPerElement * function.numElements());
+            point_data_.emplace_back(VTKDataArray(
+                s.str(), 1, gather(data_ptr, pointsPerElement * function.numElements()),
+                zlibCompress_));
         }
     }
 }
 
+template <std::size_t D> uint64_t VTUPiece<D>::make_xml(XMLElement* parent, uint64_t offset) const {
+    auto pointsPerElement = refNodes_->size();
+    auto node = parent->InsertNewChildElement("Piece");
+    node->SetAttribute("NumberOfPoints",
+                       static_cast<uint64_t>(pointsPerElement * gathered_num_elements_));
+    node->SetAttribute("NumberOfCells", static_cast<uint64_t>(gathered_num_elements_));
+
+    auto pnode = node->InsertNewChildElement("Points");
+    offset = points_.make_xml(pnode, offset);
+
+    auto cnode = node->InsertNewChildElement("Cells");
+    offset = connectivity_.make_xml(cnode, offset);
+    offset = offsets_.make_xml(cnode, offset);
+    offset = types_.make_xml(cnode, offset);
+
+    if (!cell_data_.empty()) {
+        auto cdnode = node->InsertNewChildElement("CellData");
+        for (auto const& cd : cell_data_) {
+            offset = cd.make_xml(cdnode, offset);
+        }
+    }
+
+    if (!point_data_.empty()) {
+        auto pdnode = node->InsertNewChildElement("PointData");
+        for (auto const& pd : point_data_) {
+            offset = pd.make_xml(pdnode, offset);
+        }
+    }
+
+    return offset;
+}
+
+template <std::size_t D> void VTUPiece<D>::write_appended(FILE* fp) const {
+    points_.write_appended(fp);
+    connectivity_.write_appended(fp);
+    offsets_.write_appended(fp);
+    types_.write_appended(fp);
+    for (auto const& cd : cell_data_) {
+        cd.write_appended(fp);
+    }
+    for (auto const& pd : point_data_) {
+        pd.write_appended(fp);
+    }
+}
+
+template <std::size_t D>
+uint64_t VTUWriter<D>::make_xml(XMLElement* parent, uint64_t offset) const {
+    for (auto const& piece : pieces_) {
+        offset = piece.make_xml(parent, offset);
+    }
+
+    if (!field_data_.empty()) {
+        auto fdnode = parent->InsertNewChildElement("FieldData");
+        for (auto const& fd : field_data_) {
+            offset = fd.make_xml(fdnode, offset);
+        }
+    }
+    return offset;
+}
+
+template <std::size_t D> void VTUWriter<D>::write_appended(FILE* fp) const {
+    for (auto const& piece : pieces_) {
+        piece.write_appended(fp);
+    }
+    for (auto const& fd : field_data_) {
+        fd.write_appended(fp);
+    }
+}
+
 template <std::size_t D> bool VTUWriter<D>::write(std::string const& baseName) {
-    int rank;
-    MPI_Comm_rank(comm_, &rank);
+    int wrank, grank;
+    MPI_Comm_rank(comm_, &wrank);
+    MPI_Comm_rank(group_comm_, &grank);
+
+    int is_writer = grank == 0 ? 1 : 0;
+    int writer_no;
+    int num_writers;
+    MPI_Scan(&is_writer, &writer_no, 1, mpi_type_t<int>(), MPI_SUM, comm_);
+    MPI_Allreduce(&is_writer, &num_writers, 1, mpi_type_t<int>(), MPI_SUM, comm_);
+    writer_no -= 1;
+
+    if (is_writer != 1) {
+        return true;
+    }
+
     auto formatName = [](std::string const& baseName, int rk) {
         std::stringstream nameS;
         nameS << baseName << "_" << rk << ".vtu";
         return nameS.str();
     };
 
-    std::string fileName = formatName(baseName, rank);
+    std::string fileName = formatName(baseName, writer_no);
     FILE* fp = std::fopen(fileName.c_str(), "w");
     if (!fp) {
         std::perror("Could not open file for writing");
@@ -190,7 +329,7 @@ template <std::size_t D> bool VTUWriter<D>::write(std::string const& baseName) {
         printer.OpenElement("VTKFile");
         printer.PushAttribute("type", type.c_str());
         printer.PushAttribute("version", "1.0");
-        auto headerType = DataType(header_t{});
+        auto headerType = DataType(VTKDataArray::header_t{});
         printer.PushAttribute("header_type", headerType.vtkIdentifier().c_str());
         if (isBigEndian()) {
             printer.PushAttribute("byte_order", "BigEndian");
@@ -202,17 +341,22 @@ template <std::size_t D> bool VTUWriter<D>::write(std::string const& baseName) {
         }
     };
 
+    XMLDocument doc;
+    auto grid = doc.NewElement("UnstructuredGrid");
+    doc.InsertFirstChild(grid);
+    make_xml(grid);
+
     XMLPrinter printer(fp);
     beginVTU(printer, "UnstructuredGrid");
-    doc_.Print(&printer);
+    doc.Print(&printer);
     printer.OpenElement("AppendedData");
     printer.PushAttribute("encoding", "raw");
     printer.PushText("_");
-    std::fwrite(appended_.data(), sizeof(unsigned char), appended_.size(), fp);
+    write_appended(fp);
     std::fputs("\n    </AppendedData>\n</VTKFile>\n", fp);
     std::fclose(fp);
 
-    if (rank == 0) {
+    if (writer_no == 0) {
         auto relative_base = std::filesystem::path(baseName).filename().string();
         std::string pvtuName = pvtuFileName(baseName);
         fp = std::fopen(pvtuName.c_str(), "w");
@@ -223,14 +367,14 @@ template <std::size_t D> bool VTUWriter<D>::write(std::string const& baseName) {
         XMLPrinter printer(fp);
         beginVTU(printer, "PUnstructuredGrid");
         ParallelVTUVisitor pvtu;
-        doc_.Accept(&pvtu);
+        doc.Accept(&pvtu);
         auto& pdoc = pvtu.parallelXML();
         auto grid = pdoc.FirstChildElement("PUnstructuredGrid");
         if (grid) {
             grid->SetAttribute("GhostLevel", 0);
             int commSize;
             MPI_Comm_size(comm_, &commSize);
-            for (int rk = 0; rk < commSize; ++rk) {
+            for (int rk = 0; rk < num_writers; ++rk) {
                 auto piece = grid->InsertNewChildElement("Piece");
                 piece->SetAttribute("Source", formatName(relative_base, rk).c_str());
             }

--- a/src/parallel/CommPattern.cpp
+++ b/src/parallel/CommPattern.cpp
@@ -6,6 +6,15 @@
 
 namespace tndm {
 
+void make_displs(std::vector<int> const& counts, std::vector<int>& displs,
+                 std::function<int(int)> permutation) {
+    displs.resize(counts.size());
+    displs[permutation(0)] = 0;
+    for (std::size_t p = 0; p < counts.size() - 1; ++p) {
+        displs[permutation(p + 1)] = displs[permutation(p)] + counts[permutation(p)];
+    }
+}
+
 AllToAllV::AllToAllV(std::vector<int>&& sndcnts, MPI_Comm comm)
     : sendcounts(std::move(sndcnts)), comm(comm) {
     MPI_Comm_size(comm, &procs);
@@ -14,8 +23,8 @@ AllToAllV::AllToAllV(std::vector<int>&& sndcnts, MPI_Comm comm)
     recvcounts.resize(procs);
     MPI_Alltoall(sendcounts.data(), 1, MPI_INT, recvcounts.data(), 1, MPI_INT, comm);
 
-    makeDispls(sendcounts, sdispls);
-    makeDispls(recvcounts, rdispls);
+    make_displs(sendcounts, sdispls);
+    make_displs(recvcounts, rdispls);
 }
 
 AllToAllV::AllToAllV(std::vector<int>&& sndcnts, std::vector<int>&& recvcnts, MPI_Comm comm)
@@ -24,17 +33,8 @@ AllToAllV::AllToAllV(std::vector<int>&& sndcnts, std::vector<int>&& recvcnts, MP
     assert(sendcounts.size() == procs);
     assert(recvcounts.size() == procs);
 
-    makeDispls(sendcounts, sdispls);
-    makeDispls(recvcounts, rdispls);
-}
-
-void AllToAllV::makeDispls(std::vector<int> const& counts, std::vector<int>& displs,
-                           std::function<int(int)> permutation) {
-    displs.resize(counts.size());
-    displs[permutation(0)] = 0;
-    for (std::size_t p = 0; p < counts.size() - 1; ++p) {
-        displs[permutation(p + 1)] = displs[permutation(p)] + counts[permutation(p)];
-    }
+    make_displs(sendcounts, sdispls);
+    make_displs(recvcounts, rdispls);
 }
 
 void AllToAllV::swap() {
@@ -43,8 +43,23 @@ void AllToAllV::swap() {
 }
 
 void AllToAllV::setRankPermutation(std::vector<int> const& permutation) {
-    makeDispls(sendcounts, sdispls, [&permutation](int p) { return permutation[p]; });
-    makeDispls(recvcounts, rdispls, [&permutation](int p) { return permutation[p]; });
+    make_displs(sendcounts, sdispls, [&permutation](int p) { return permutation[p]; });
+    make_displs(recvcounts, rdispls, [&permutation](int p) { return permutation[p]; });
+}
+
+GatherV::GatherV(int sendcount, int root, MPI_Comm comm)
+    : sendcount_(sendcount), root_(root), comm_(comm) {
+    int rank, size;
+    MPI_Comm_rank(comm_, &rank);
+    MPI_Comm_size(comm_, &size);
+    if (rank == root_) {
+        recvcounts_.resize(size);
+    }
+    MPI_Gather(&sendcount, 1, mpi_type_t<int>(), recvcounts_.data(), 1, mpi_type_t<int>(), root_,
+               comm_);
+    if (rank == root_) {
+        make_displs(recvcounts_, displs_);
+    }
 }
 
 } // namespace tndm

--- a/src/parallel/MPITraits.h
+++ b/src/parallel/MPITraits.h
@@ -5,34 +5,60 @@
 
 namespace tndm {
 
-template<typename T> struct mpi_type;
-template<typename T> inline MPI_Datatype mpi_type_t() { return mpi_type<T>::type(); }
+template <typename T> struct mpi_type;
+template <typename T> inline MPI_Datatype mpi_type_t() { return mpi_type<T>::type(); }
 
 // integer types
-template<> struct mpi_type<int> { static MPI_Datatype type() { return MPI_INT; } };
-template<> struct mpi_type<long> { static MPI_Datatype type() { return MPI_LONG; } };
-template<> struct mpi_type<long long> { static MPI_Datatype type() { return MPI_LONG_LONG; } };
-template<> struct mpi_type<unsigned> { static MPI_Datatype type() { return MPI_UNSIGNED; } };
-template<> struct mpi_type<unsigned long> { static MPI_Datatype type() { return MPI_UNSIGNED_LONG; } };
-template<> struct mpi_type<unsigned long long> { static MPI_Datatype type() { return MPI_UNSIGNED_LONG_LONG; } };
+template <> struct mpi_type<char> {
+    static MPI_Datatype type() { return MPI_CHAR; }
+};
+template <> struct mpi_type<short> {
+    static MPI_Datatype type() { return MPI_SHORT; }
+};
+template <> struct mpi_type<int> {
+    static MPI_Datatype type() { return MPI_INT; }
+};
+template <> struct mpi_type<long> {
+    static MPI_Datatype type() { return MPI_LONG; }
+};
+template <> struct mpi_type<long long> {
+    static MPI_Datatype type() { return MPI_LONG_LONG; }
+};
+template <> struct mpi_type<unsigned char> {
+    static MPI_Datatype type() { return MPI_UNSIGNED_CHAR; }
+};
+template <> struct mpi_type<unsigned short> {
+    static MPI_Datatype type() { return MPI_UNSIGNED_SHORT; }
+};
+template <> struct mpi_type<unsigned int> {
+    static MPI_Datatype type() { return MPI_UNSIGNED; }
+};
+template <> struct mpi_type<unsigned long> {
+    static MPI_Datatype type() { return MPI_UNSIGNED_LONG; }
+};
+template <> struct mpi_type<unsigned long long> {
+    static MPI_Datatype type() { return MPI_UNSIGNED_LONG_LONG; }
+};
 
 // floating point types
-template<> struct mpi_type<float> { static MPI_Datatype type() { return MPI_FLOAT; } };
-template<> struct mpi_type<double> { static MPI_Datatype type() { return MPI_DOUBLE; } };
+template <> struct mpi_type<float> {
+    static MPI_Datatype type() { return MPI_FLOAT; }
+};
+template <> struct mpi_type<double> {
+    static MPI_Datatype type() { return MPI_DOUBLE; }
+};
 
-template<typename T>
-class mpi_array_type {
+template <typename T> class mpi_array_type {
 public:
     mpi_array_type(int count) {
         MPI_Type_contiguous(count, mpi_type_t<T>(), &type);
         MPI_Type_commit(&type);
     }
 
-    ~mpi_array_type() {
-        MPI_Type_free(&type);
-    }
+    ~mpi_array_type() { MPI_Type_free(&type); }
 
     MPI_Datatype const& get() const { return type; }
+
 private:
     MPI_Datatype type;
 };


### PR DESCRIPTION
After a job created 4179176 vtk files... I thought it would be useful to gather the data node-wise before writing. With this PR the number of files is reduced to a mere 97696 vtk files.

The data is gathered is by splitting the communicator in the VTUWriter constructor as following:
```
MPI_Comm_split_type(comm_, MPI_COMM_TYPE_SHARED, 0, MPI_INFO_NULL, &group_comm_);
```
The behaviour is hard-coded. However, one can quite easily change the behaviour by splitting the communicator differently.

@dmay23 any comments?