### PR TITLE
add missing include and cherry-pick Casper's commit fixing compilation without libxsmm

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -82,9 +82,9 @@ function(generate_code APP)
     if("${YATETO_ARCH}" MATCHES "skl|naples|rome")
         set(YATETO_ARCH "hsw")
     endif()
-    set(WITH_LIBXSMM "")
+    set(WITH_LIBXSMM "\'\'")
     if(${LibxsmmGenerator_FOUND})
-        set(WITH_LIBXSMM ${LibxsmmGeneratorExecutable})
+        set(WITH_LIBXSMM "\'${LibxsmmGeneratorExecutable}\'")
     endif()
     add_custom_command(
         COMMAND

--- a/src/mesh/Simplex.h
+++ b/src/mesh/Simplex.h
@@ -7,7 +7,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <utility>
-
+#include <limits>
 #include "util/Combinatorics.h"
 
 namespace tndm {


### PR DESCRIPTION
- adding the missing include fixed the compilation on supermuc (maybe only needed with GCC 11.2.0)
- cherry-pick Casper's commit fixing the compilation without libxsmm.