### PR TITLE
Document installation procedure with spack

### DIFF
--- a/docs/getting-started/installation.rst
+++ b/docs/getting-started/installation.rst
@@ -147,6 +147,7 @@ Install METIS and ParMETIS
     # make config && make && make install
     # cd ../parmetis-4.0.3
     # make config && make && make install
+    # cd ..
 
 Install PETSc
 -------------
@@ -163,6 +164,7 @@ Install PETSc
          COPTFLAGS="-g -O3" CXXOPTFLAGS="-g -O3"
     # make PETSC_DIR=`pwd` PETSC_ARCH=arch-linux-c-opt -j
     # make PETSC_DIR=`pwd` PETSC_ARCH=arch-linux-c-opt install
+    # cd ..
 
 (Optional) Install libxsmm
 --------------------------
@@ -174,6 +176,7 @@ Install PETSc
     # cd libxsmm-1.16.1
     # make -j generator
     # cp bin/libxsmm_gemm_generator /usr/local/bin/
+    # cd ..
 
 Compile tandem
 --------------

--- a/docs/getting-started/installation.rst
+++ b/docs/getting-started/installation.rst
@@ -1,7 +1,103 @@
 Installation
 ============
 
-In order to compile tandem natively you need to install dependencies.
+Tandem and its dependencies can be installed automatically with `Spack <https://github.com/spack/spack/wiki>`_, or manually.
+
+Spack installation
+------------------
+
+`Spack <https://github.com/spack/spack/wiki>`_ is an HPC software package manager.
+It automates the process of installing, upgrading, configuring, and removing computer programs.
+In particular, the spack package ``tandem`` allows automatically installing tandem and all its dependencies, and creating environment modules.
+First, install spack with, e.g.
+
+.. code-block:: bash
+
+    cd $HOME
+    git clone --depth 1 https://github.com/spack/spack.git
+    cd spack
+    echo "export SPACK_ROOT=$PWD" >> $HOME/.bashrc
+    echo "export PATH=\$SPACK_ROOT/bin:\$PATH" >> $HOME/.bashrc
+
+Then install tandem with:
+
+.. code-block:: bash
+
+    spack install tandem polynomial_degree=3 domain_dimension=2
+
+tandem can then be already loaded with ``spack load tandem``.
+Alternatively, we might prefer loading tandem from environment modules. We therefore now detail the procedure to generate such a module.
+The path where the module file should be installed and the name of the generated module files can be enhanced by updating ``~/.spack/modules.yaml`` with:
+
+.. code-block:: yaml
+
+    modules:
+      default:
+        roots:
+         tcl: your_custom_path_2_modules
+      default:
+        tcl:
+          all:
+            suffixes:
+              domain_dimension=2: 'd2'
+              domain_dimension=3: 'd3'
+              polynomial_degree=1: 'p1'
+              polynomial_degree=2: 'p2'
+              polynomial_degree=3: 'p3'
+              polynomial_degree=4: 'p4'
+              polynomial_degree=5: 'p5'
+              polynomial_degree=6: 'p6
+
+Note that a custom install directory for spack packages can also be set, by changing ``~/.spack/config.yaml``:
+
+.. code-block:: yaml
+
+    config:
+      install_tree: path_2_packages
+
+We can then generate a module file with:
+
+.. code-block:: bash
+
+    spack module tcl refresh tandem
+
+to access the module at start up, add to your ``~/.bashrc``:
+
+.. code-block:: bash
+
+    module use your_custom_path_2_modules/your_spack_arch_string
+
+e.g.:
+
+.. code-block:: bash
+
+    module use $HOME/spack/modules/x86_avx512/linux-sles15-skylake_avx512/
+
+SuperMUC-NG installation
+------------------------
+
+SuperMUC-NG modules have been installed with spack, but the version is too old and does not know natively how to compile tandem. We then need to add it using a repository:
+
+.. code-block:: bash
+
+    # load spack
+    module load user_spack
+    # clone seissol-spack-aid and add the repository
+    git clone --branch supermuc_NG https://github.com/SeisSol/seissol-spack-aid.git
+    cd seissol-spack-aid
+    spack repo add ./spack
+
+Then tandem can be installed, e.g. with:
+
+.. code-block:: bash
+
+    spack install tandem polynomial_degree=3 domain_dimension=2 target=skylake_avx512 %intel@21.4.0 ^intel-mpi@2019.12.320
+
+The procedure to create an environment module is the same as detailed above.
+
+Manual installation
+-------------------
+
 The following dependencies are likely available via your package manager:
 
 - A recent C++-17 capable compiler (we recommend GCC ≥ 8.0 or clang ≥ 8)
@@ -17,6 +113,7 @@ The following dependencies likely need to be installed manually:
 - `METIS <http://glaros.dtc.umn.edu/gkhome/metis/metis/overview>`_ (≥ 5.1) and `ParMETIS <http://glaros.dtc.umn.edu/gkhome/metis/parmetis/overview>`_ (≥ 4.0)
 - `PETSc <https://www.mcs.anl.gov/petsc/>`_ (≥ 3.13)
 - (Optional) `libxsmm <https://github.com/hfp/libxsmm>`_ (= 1.16.1)
+
 
 Dependencies via package manager
 --------------------------------

--- a/docs/getting-started/installation.rst
+++ b/docs/getting-started/installation.rst
@@ -76,6 +76,8 @@ e.g.:
 SuperMUC-NG installation
 ------------------------
 
+First, have a look at `this page <https://seissol.readthedocs.io/en/latest/behind_firewall.html>`_ to best configure git on SuperMUC-NG.
+
 The software stack on SuperMUC-NG has been installed with spack.
 Yet, spack on SuperMUC-NG is not recent enough to natively know how to compile tandem. 
 The recipe for compiling spack should then be added from a repository:

--- a/docs/getting-started/installation.rst
+++ b/docs/getting-started/installation.rst
@@ -25,9 +25,9 @@ Then install tandem with:
 
     spack install tandem@main polynomial_degree=3 domain_dimension=2
 
-tandem can then be already loaded with ``spack load tandem``.
-Alternatively, we might prefer loading tandem from environment modules. We therefore now detail the procedure to generate such a module.
-The path where the module file should be installed (if e.g. you do not want to install on /home because you want to share your installation with other users), and the name of the generated module files can be enhanced by updating ``~/.spack/modules.yaml`` with:
+tandem can then be loaded with ``spack load tandem``.
+Alternatively, we might prefer loading tandem from environment modules. We therefore now detail the procedure to generate such module(s).
+You may want to update ``~/.spack/modules.yaml``, to specify the path where the module file(s) should be installed (if e.g. if want to share your installation with other users and they cannot access your $HOME), and to generate module files with more readable names:
 
 .. code-block:: yaml
 
@@ -55,7 +55,7 @@ Note that a custom install directory for spack packages can also be set, by chan
     config:
       install_tree: path_2_packages
 
-We can then generate a module file with:
+We can then generate a tandem module file with:
 
 .. code-block:: bash
 
@@ -76,7 +76,9 @@ e.g.:
 SuperMUC-NG installation
 ------------------------
 
-SuperMUC-NG modules have been installed with spack, but the version is too old and does not know natively how to compile tandem. We then need to add it using a repository:
+The software stack on SuperMUC-NG has been installed with spack.
+Yet, spack on SuperMUC-NG is not recent enough to natively know how to compile tandem. 
+The recipe for compiling spack should then be added from a repository:
 
 .. code-block:: bash
 
@@ -87,7 +89,7 @@ SuperMUC-NG modules have been installed with spack, but the version is too old a
     cd seissol-spack-aid
     spack repo add ./spack
 
-Then tandem can be installed, e.g. with:
+tandem can be then installed, e.g. with:
 
 .. code-block:: bash
 
@@ -149,9 +151,9 @@ Install PETSc
 
 .. code:: console
 
-    # wget http://ftp.mcs.anl.gov/pub/petsc/release-snapshots/petsc-lite-3.13.3.tar.gz
-    # tar -xvf petsc-lite-3.13.3.tar.gz
-    # cd petsc-3.13.3
+    # wget http://ftp.mcs.anl.gov/pub/petsc/release-snapshots/petsc-lite-3.14.6.tar.gz
+    # tar -xvf petsc-lite-3.14.6.tar.gz
+    # cd petsc-3.14.6
     # ./configure --with-fortran-bindings=0 --with-debugging=0 \
          --with-memalign=32 --with-64-bit-indices \
          CC=mpicc CXX=mpicxx FC=mpif90 --prefix=/usr/local/ \

--- a/docs/getting-started/installation.rst
+++ b/docs/getting-started/installation.rst
@@ -91,7 +91,7 @@ Then tandem can be installed, e.g. with:
 
 .. code-block:: bash
 
-    spack install@main tandem polynomial_degree=3 domain_dimension=2 target=skylake_avx512 %intel@21.4.0 ^intel-mpi@2019.12.320
+    spack install tandem@main polynomial_degree=3 domain_dimension=2 target=skylake_avx512 %intel@21.4.0 ^intel-mpi@2019.12.320
 
 The procedure to create an environment module is the same as detailed above.
 

--- a/docs/getting-started/installation.rst
+++ b/docs/getting-started/installation.rst
@@ -46,7 +46,7 @@ You may want to update ``~/.spack/modules.yaml``, to specify the path where the 
               polynomial_degree=3: 'p3'
               polynomial_degree=4: 'p4'
               polynomial_degree=5: 'p5'
-              polynomial_degree=6: 'p6
+              polynomial_degree=6: 'p6'
 
 Note that a custom install directory for spack packages can also be set, by changing ``~/.spack/config.yaml``:
 

--- a/docs/getting-started/installation.rst
+++ b/docs/getting-started/installation.rst
@@ -91,7 +91,7 @@ Then tandem can be installed, e.g. with:
 
 .. code-block:: bash
 
-    spack install tandem@main polynomial_degree=3 domain_dimension=2 target=skylake_avx512 %intel@21.4.0 ^intel-mpi@2019.12.320
+    spack install tandem@main polynomial_degree=3 domain_dimension=2 target=skylake_avx512
 
 The procedure to create an environment module is the same as detailed above.
 

--- a/docs/getting-started/installation.rst
+++ b/docs/getting-started/installation.rst
@@ -23,11 +23,11 @@ Then install tandem with:
 
 .. code-block:: bash
 
-    spack install tandem polynomial_degree=3 domain_dimension=2
+    spack install tandem@main polynomial_degree=3 domain_dimension=2
 
 tandem can then be already loaded with ``spack load tandem``.
 Alternatively, we might prefer loading tandem from environment modules. We therefore now detail the procedure to generate such a module.
-The path where the module file should be installed and the name of the generated module files can be enhanced by updating ``~/.spack/modules.yaml`` with:
+The path where the module file should be installed (if e.g. you do not want to install on /home because you want to share your installation with other users), and the name of the generated module files can be enhanced by updating ``~/.spack/modules.yaml`` with:
 
 .. code-block:: yaml
 
@@ -91,7 +91,7 @@ Then tandem can be installed, e.g. with:
 
 .. code-block:: bash
 
-    spack install tandem polynomial_degree=3 domain_dimension=2 target=skylake_avx512 %intel@21.4.0 ^intel-mpi@2019.12.320
+    spack install@main tandem polynomial_degree=3 domain_dimension=2 target=skylake_avx512 %intel@21.4.0 ^intel-mpi@2019.12.320
 
 The procedure to create an environment module is the same as detailed above.
 


### PR DESCRIPTION
I've added documentation of the procedure to install tandem with spack.
Note that it will not fully work now, until 
- the tandem module is reviewed and accepted by spack (should take less than 1 week).
- the PR with missing include is merged.
(as a work-around, following the procedure for installing tandem on SuperMUC should work, apart from the include). 