### PR TITLE
Add support for time dependent stress perturbations. 

### DIFF
--- a/app/tandem/Context.h
+++ b/app/tandem/Context.h
@@ -73,6 +73,9 @@ public:
         if (friction_scenario->delta_tau_fun()) {
             fric->lop().set_delta_tau_fun(*friction_scenario->delta_tau_fun());
         }
+        if (friction_scenario->delta_sn_fun()) {
+            fric->lop().set_delta_sn_fun(*friction_scenario->delta_sn_fun());
+        }
         return fric;
     }
     auto adapter() -> std::unique_ptr<AbstractAdapterOperator> override {

--- a/app/tandem/FrictionConfig.h
+++ b/app/tandem/FrictionConfig.h
@@ -40,6 +40,7 @@ public:
     constexpr static char Sinit[] = "Sinit";
     constexpr static char Source[] = "source";
     constexpr static char DeltaTau[] = "delta_tau";
+    constexpr static char DeltaSn[] = "delta_sn";
     constexpr static char FaultSolution[] = "fault_solution";
 
     DieterichRuinaAgeingScenario(std::string const& lib, std::string const& scenario) {
@@ -74,6 +75,12 @@ public:
                                        DieterichRuinaAgeing::TangentialComponents>(scenario,
                                                                                    DeltaTau));
         }
+        if (lib_.hasMember(scenario, DeltaSn)) {
+            delta_sn_ = std::make_optional(
+                lib_.getMemberFunction<DomainDimension + 1,
+                                       1>(scenario,
+                                                                                   DeltaSn));
+        }
 
         cp_.V0 = lib_.getMemberConstant(scenario, V0);
         cp_.b = lib_.getMemberConstant(scenario, B);
@@ -102,6 +109,7 @@ public:
     }
     auto const& source_fun() const { return source_; }
     auto const& delta_tau_fun() const { return delta_tau_; }
+    auto const& delta_sn_fun() const { return delta_sn_; }
     std::unique_ptr<SolutionInterface> solution(double time) const {
         if (solution_) {
             auto sol = *solution_;
@@ -124,6 +132,7 @@ protected:
         -> std::array<double, DieterichRuinaAgeing::TangentialComponents> { return {}; };
     std::optional<functional_t<DomainDimension + 1>> source_ = std::nullopt;
     std::optional<vector_functional_t<DomainDimension + 1>> delta_tau_ = std::nullopt;
+    std::optional<functional_t<DomainDimension + 1>> delta_sn_ = std::nullopt;
     std::optional<SeasSolution<NumQuantities>> solution_ = std::nullopt;
 };
 


### PR DESCRIPTION
To this feature, add the following two Lua methods in your Lua model file

```
function X:delta_tau(x, y, z, t) 
  return 0.0, 0.0
end
```

and 

```
function X:delta_sn(x, y, z, t) 
  return 0.0
end
```

where X is the Lua model name.

In 3D, delta_tau() and delta_sn() accept the args x, y, z, t. 
In 2D, delta_tau() and delta_sn() accept the args x, y, t. 
If the spatial dimension of your domain is D, then detlta_tau() will return a D-1 vector. delta_sn() returns a scalar independent of D.
