### PR TITLE
Allow creating outputs file when simulation starts at non-zero time

### DIFF
--- a/src/io/BoundaryProbeWriter.cpp
+++ b/src/io/BoundaryProbeWriter.cpp
@@ -8,6 +8,8 @@
 #include <sstream>
 #include <unordered_map>
 #include <unordered_set>
+#include <filesystem>
+namespace fs = std::filesystem;
 
 namespace tndm {
 
@@ -83,7 +85,17 @@ void BoundaryProbeWriter<D>::write(double time,
             out_->open(probe.file_name, false);
             write_header(probe, functions);
         } else {
-            out_->open(probe.file_name, true);
+            fs::path pckp(probe.file_name);
+            bool exists = fs::exists(pckp);
+            if (exists) {
+                // open existing file
+                out_->open(probe.file_name, true);
+            } else { // below is needed to support checkpointing
+                // open new file
+                out_->open(probe.file_name, false);
+                // write header
+                write_header(probe, functions);
+            }
         }
 
         *out_ << time;

--- a/src/io/BoundaryProbeWriter.cpp
+++ b/src/io/BoundaryProbeWriter.cpp
@@ -9,7 +9,6 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <filesystem>
-namespace fs = std::filesystem;
 
 namespace tndm {
 
@@ -85,15 +84,10 @@ void BoundaryProbeWriter<D>::write(double time,
             out_->open(probe.file_name, false);
             write_header(probe, functions);
         } else {
-            fs::path pckp(probe.file_name);
-            bool exists = fs::exists(pckp);
-            if (exists) {
-                // open existing file
+            if (std::filesystem::exists(probe.file_name)) {
                 out_->open(probe.file_name, true);
-            } else { // below is needed to support checkpointing
-                // open new file
+            } else {
                 out_->open(probe.file_name, false);
-                // write header
                 write_header(probe, functions);
             }
         }

--- a/src/io/ProbeWriter.cpp
+++ b/src/io/ProbeWriter.cpp
@@ -7,6 +7,7 @@
 #include <sstream>
 #include <unordered_map>
 #include <unordered_set>
+#include <filesystem>
 
 namespace tndm {
 
@@ -81,7 +82,12 @@ void ProbeWriter<D>::write(double time, mneme::span<FiniteElementFunction<D>> fu
             out_->open(probe.file_name, false);
             write_header(probe, functions);
         } else {
-            out_->open(probe.file_name, true);
+            if (std::filesystem::exists(probe.file_name)) {
+                out_->open(probe.file_name, true);
+            } else {
+                out_->open(probe.file_name, false);
+                write_header(probe, functions);
+            }
         }
 
         *out_ << time;

--- a/src/io/ScalarWriter.cpp
+++ b/src/io/ScalarWriter.cpp
@@ -3,7 +3,6 @@
 #include <iomanip>
 #include <ios>
 #include <filesystem>
-namespace fs = std::filesystem;
 
 namespace tndm {
 
@@ -21,15 +20,10 @@ void ScalarWriter::write(double time, mneme::span<double> scalars) const {
         out_->open(file_name_, false);
         write_header();
     } else {
-        fs::path pckp(file_name_);
-        bool exists = fs::exists(pckp);
-        if (exists) {
-            // open existing file
+        if (std::filesystem::exists(probe.file_name_)) {
             out_->open(file_name_, true);
-        } else { // below is needed to support checkpointing
-            // open new file
+        } else {
             out_->open(file_name_, false);
-            // write header
             write_header();
         }
     }

--- a/src/io/ScalarWriter.cpp
+++ b/src/io/ScalarWriter.cpp
@@ -2,6 +2,8 @@
 
 #include <iomanip>
 #include <ios>
+#include <filesystem>
+namespace fs = std::filesystem;
 
 namespace tndm {
 
@@ -19,7 +21,17 @@ void ScalarWriter::write(double time, mneme::span<double> scalars) const {
         out_->open(file_name_, false);
         write_header();
     } else {
-        out_->open(file_name_, true);
+        fs::path pckp(file_name_);
+        bool exists = fs::exists(pckp);
+        if (exists) {
+            // open existing file
+            out_->open(file_name_, true);
+        } else { // below is needed to support checkpointing
+            // open new file
+            out_->open(file_name_, false);
+            // write header
+            write_header();
+        }
     }
 
     *out_ << time;

--- a/src/io/ScalarWriter.cpp
+++ b/src/io/ScalarWriter.cpp
@@ -20,7 +20,7 @@ void ScalarWriter::write(double time, mneme::span<double> scalars) const {
         out_->open(file_name_, false);
         write_header();
     } else {
-        if (std::filesystem::exists(probe.file_name_)) {
+        if (std::filesystem::exists(file_name_)) {
             out_->open(file_name_, true);
         } else {
             out_->open(file_name_, false);


### PR DESCRIPTION
The changes are made to allow the creation of probe outputs when the simulation starts at non-zero time. This feature might be useful in the case of loading checkpoints.