### PR TITLE
Allowing state variable evolution law as a compile-time choice

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -52,15 +52,15 @@ add_custom_command(
 )
 
 # Define options for state evolution law
-set(FRICION_LAW "aging" CACHE STRING "Define the state variable evolution law")
-if (FRICION_LAW STREQUAL "aging")
-    add_definitions(-DAGING_LAW)
-    message(STATUS "State evolution law: Aging")
-elseif (FRICION_LAW STREQUAL "slip")
-    add_definitions(-DSLIP_LAW)
-    message(STATUS "State evolution law: Slip")
+set(FRICTION_LAW "dieterich_ruina_aging" CACHE STRING "Define the state variable evolution law")
+if (FRICTION_LAW STREQUAL "dieterich_ruina_aging")
+    add_definitions(-DDR_AGING_LAW)
+    message(STATUS "State evolution law: Dieterich-Ruina Aging Law")
+elseif (FRICTION_LAW STREQUAL "dieterich_ruina_slip")
+    add_definitions(-DDR_SLIP_LAW)
+    message(STATUS "State evolution law: Dieterich-Ruina Slip Law")
 else()
-    message(FATAL_ERROR "Cannot recognize the given option. Your option should be either aging or slip.")
+    message(FATAL_ERROR "Cannot recognize the given option. Your option should be either [dieterich_ruina_aging] or [dieterich_ruina_slip].")
 endif()
 
 # Generate kernels

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -51,6 +51,18 @@ add_custom_command(
         ${OPTIONS_FILE_NAME}
 )
 
+# Define options for state evolution law
+set(FRICION_LAW "aging" CACHE STRING "Define the state variable evolution law")
+if (FRICION_LAW STREQUAL "aging")
+    add_definitions(-DAGING_LAW)
+    message(STATUS "State evolution law: Aging")
+elseif (FRICION_LAW STREQUAL "slip")
+    add_definitions(-DSLIP_LAW)
+    message(STATUS "State evolution law: Slip")
+else()
+    message(FATAL_ERROR "Cannot recognize the given option. Your option should be either aging or slip.")
+endif()
+
 # Generate kernels
 
 if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.13)

--- a/app/localoperator/DieterichRuinaAgeing.h
+++ b/app/localoperator/DieterichRuinaAgeing.h
@@ -153,7 +153,7 @@ public:
         }
     }
 
-private:
+protected:
     double F(std::size_t index, double snAbs, double V, double psi) const {
         auto a = p_[index].get<A>();
         double e = exp(psi / a);

--- a/app/localoperator/DieterichRuinaAging.h
+++ b/app/localoperator/DieterichRuinaAging.h
@@ -1,9 +1,10 @@
-#ifndef DIETERICHRUINAAGING_20201027_H
-#define DIETERICHRUINAAGING_20201027_H
+#ifndef DIETERICHRUINAGING_20241105_H
+#define DIETERICHRUINAGING_20241105_H
 
 #include "config.h"
 
 #include "geometry/Vector.h"
+#include "localoperator/DieterichRuinaBase.h"
 #include "tensor/Tensor.h"
 #include "util/Zero.h"
 
@@ -17,186 +18,14 @@
 
 namespace tndm {
 
-class DieterichRuinaAging {
+class DieterichRuinaAging : public DieterichRuinaBase {
 public:
-    static constexpr std::size_t TangentialComponents = DomainDimension - 1u;
-
-    struct ConstantParams {
-        double V0;
-        double b;
-        double f0;
-    };
-    struct Params {
-        double a;
-        double eta;
-        double L;
-        double sn_pre;
-        std::array<double, TangentialComponents> tau_pre;
-        std::array<double, TangentialComponents> Vinit;
-        std::array<double, TangentialComponents> Sinit;
-    };
-
-    void set_num_nodes(std::size_t num_nodes) { p_.resize(num_nodes); }
-    void set_constant_params(ConstantParams const& params) { cp_ = params; }
-    void set_params(std::size_t index, Params const& params) {
-        p_[index].get<A>() = params.a;
-        p_[index].get<Eta>() = params.eta;
-        p_[index].get<L>() = params.L;
-        p_[index].get<SnPre>() = params.sn_pre;
-        p_[index].get<TauPre>() = params.tau_pre;
-        p_[index].get<Vinit>() = params.Vinit;
-        p_[index].get<Sinit>() = params.Sinit;
-    }
-
-    double psi_init(std::size_t index, double sn,
-                    std::array<double, TangentialComponents> const& tau) const {
-        double snAbs = -sn + p_[index].get<SnPre>();
-        double tauAbs = norm(tau + p_[index].get<TauPre>());
-        auto Vi = norm(p_[index].get<Vinit>());
-        if (Vi == 0.0) {
-            return cp_.f0;
-        }
-        auto a = p_[index].get<A>();
-        auto eta = p_[index].get<Eta>();
-        double s = sinh((tauAbs - eta * Vi) / (a * snAbs));
-        double l = log((2.0 * cp_.V0 / Vi) * s);
-        return a * l;
-    }
-
-    /**
-     * @brief Absolute normal stress on fault (positive in compression)
-     */
-    double sn_hat(std::size_t index, double sn) const { return -sn + p_[index].get<SnPre>(); }
-    /**
-     * @brief Absolute shear stress on fault.
-     *
-     * Includes radiation damping term. I.e. the returned value is equivalent to -sn_hat f(V, psi).
-     */
-    auto tau_hat(std::size_t index, std::array<double, TangentialComponents> const& tau,
-                 std::array<double, TangentialComponents> const& V) const {
-        return tau + p_[index].get<TauPre>() + p_[index].get<Eta>() * V;
-    }
-    auto S_init(std::size_t index) const { return p_[index].get<Sinit>(); }
-
-    auto slip_rate(std::size_t index, double sn,
-                   std::array<double, TangentialComponents> const& tau, double psi) const
-        -> std::array<double, TangentialComponents> {
-        auto eta = p_[index].get<Eta>();
-        auto tauAbsVec = tau + p_[index].get<TauPre>();
-        double snAbs = -sn + p_[index].get<SnPre>();
-        double tauAbs = norm(tauAbsVec);
-        double V = 0.0;
-        if (eta == 0.0) {
-            V = Finv(index, snAbs, tauAbs, psi);
-        } else {
-            if (snAbs <= 0.0) { /* Implies the fault is experiencing tension / opening */
-                snAbs = 0.0; /* Just to illustrate what we are doing */
-                /* Solve R(V) = T - sigma_n F(V,psi) - eta V with sigma_n = 0.0 */
-                V = tauAbs / eta;
-            } else {
-                double a = 0.0;
-                double b = tauAbs / eta;
-                if (a > b) {
-                    std::swap(a, b);
-                }
-                auto fF = [this, &index, &snAbs, &tauAbs, &psi, &eta](double V) {
-                    return tauAbs - this->F(index, snAbs, V, psi) - eta * V;
-                };
-                try {
-                    V = zeroIn(a, b, fF);
-                } catch (std::exception const&) {
-                    std::cout << "sigma_n = " << snAbs << std::endl
-                              << "|tau| = " << tauAbs << std::endl
-                              << "psi = " << psi << std::endl
-                              << "L = " << a << std::endl
-                              << "U = " << b << std::endl
-                              << "F(L) = " << fF(a) << std::endl
-                              << "F(U) = " << fF(b) << std::endl;
-                    throw;
-                }
-            }
-        }
-        return -(V / tauAbs) * tauAbsVec;
-    }
-
-    double state_rhs(std::size_t index, double V, double psi) const {
+    double state_rhs(std::size_t index, double V, double psi) const override {
         double myL = p_[index].get<L>();
         return cp_.b * cp_.V0 / myL * (exp((cp_.f0 - psi) / cp_.b) - V / cp_.V0);
     }
-
-    auto param_names() const {
-        auto names = std::vector<std::string>(4 + TangentialComponents);
-        char buf[100];
-
-        std::size_t i = 0;
-        names[i++] = "a";
-        names[i++] = "eta";
-        names[i++] = "L";
-        names[i++] = "sn_pre";
-        for (std::size_t t = 0; t < TangentialComponents; ++t) {
-            snprintf(buf, sizeof(buf), "tau_pre%lu", t);
-            names[i++] = buf;
-        }
-        return names;
-    }
-
-    template <typename VecT> void params(std::size_t index, VecT& result) const {
-        assert(result.shape(0) == 4 + TangentialComponents);
-        std::ptrdiff_t i = 0;
-        result(i++) = p_[index].get<A>();
-        result(i++) = p_[index].get<Eta>();
-        result(i++) = p_[index].get<L>();
-        result(i++) = p_[index].get<SnPre>();
-        auto const& tau_pre = p_[index].get<TauPre>();
-        for (auto const& t : tau_pre) {
-            result(i++) = t;
-        }
-    }
-
-protected:
-    double F(std::size_t index, double snAbs, double V, double psi) const {
-        auto a = p_[index].get<A>();
-        double e = exp(psi / a);
-        double f = a * asinh((V / (2.0 * cp_.V0)) * e);
-        return snAbs * f;
-    }
-
-    double Finv(std::size_t index, double snAbs, double tauAbs, double psi) const {
-        // We have
-        // V = 2 V_0 sinh(tauAbs / (a snAbs)) exp(-psi / a)
-        // substituting r = tauAbs / snAbs and sinh(x) = (exp(x) - exp(-x)) / 2 we obtain
-        // V = V_0 (exp((r - psi) / a) - exp(-(r + psi) / a))
-        auto a = p_[index].get<A>();
-        double r = tauAbs / snAbs;
-        return cp_.V0 * (exp((r - psi) / a) - exp(-(r + psi) / a));
-    }
-
-    ConstantParams cp_;
-
-    struct SnPre {
-        using type = double;
-    };
-    struct TauPre {
-        using type = std::array<double, TangentialComponents>;
-    };
-    struct A {
-        using type = double;
-    };
-    struct Eta {
-        using type = double;
-    };
-    struct L {
-        using type = double;
-    };
-    struct Vinit {
-        using type = std::array<double, TangentialComponents>;
-    };
-    struct Sinit {
-        using type = std::array<double, TangentialComponents>;
-    };
-    mneme::MultiStorage<mneme::DataLayout::SoA, SnPre, TauPre, A, Eta, L, Vinit, Sinit> p_;
 };
 
 } // namespace tndm
 
-#endif // DIETERICHRUINAAGING_20201027_H
+#endif // DIETERICHRUINAAGING_20241105_H

--- a/app/localoperator/DieterichRuinaAging.h
+++ b/app/localoperator/DieterichRuinaAging.h
@@ -1,0 +1,202 @@
+#ifndef DIETERICHRUINAAGING_20201027_H
+#define DIETERICHRUINAAGING_20201027_H
+
+#include "config.h"
+
+#include "geometry/Vector.h"
+#include "tensor/Tensor.h"
+#include "util/Zero.h"
+
+#include "mneme/storage.hpp"
+
+#include <algorithm>
+#include <cassert>
+#include <cstddef>
+#include <exception>
+#include <iostream>
+
+namespace tndm {
+
+class DieterichRuinaAging {
+public:
+    static constexpr std::size_t TangentialComponents = DomainDimension - 1u;
+
+    struct ConstantParams {
+        double V0;
+        double b;
+        double f0;
+    };
+    struct Params {
+        double a;
+        double eta;
+        double L;
+        double sn_pre;
+        std::array<double, TangentialComponents> tau_pre;
+        std::array<double, TangentialComponents> Vinit;
+        std::array<double, TangentialComponents> Sinit;
+    };
+
+    void set_num_nodes(std::size_t num_nodes) { p_.resize(num_nodes); }
+    void set_constant_params(ConstantParams const& params) { cp_ = params; }
+    void set_params(std::size_t index, Params const& params) {
+        p_[index].get<A>() = params.a;
+        p_[index].get<Eta>() = params.eta;
+        p_[index].get<L>() = params.L;
+        p_[index].get<SnPre>() = params.sn_pre;
+        p_[index].get<TauPre>() = params.tau_pre;
+        p_[index].get<Vinit>() = params.Vinit;
+        p_[index].get<Sinit>() = params.Sinit;
+    }
+
+    double psi_init(std::size_t index, double sn,
+                    std::array<double, TangentialComponents> const& tau) const {
+        double snAbs = -sn + p_[index].get<SnPre>();
+        double tauAbs = norm(tau + p_[index].get<TauPre>());
+        auto Vi = norm(p_[index].get<Vinit>());
+        if (Vi == 0.0) {
+            return cp_.f0;
+        }
+        auto a = p_[index].get<A>();
+        auto eta = p_[index].get<Eta>();
+        double s = sinh((tauAbs - eta * Vi) / (a * snAbs));
+        double l = log((2.0 * cp_.V0 / Vi) * s);
+        return a * l;
+    }
+
+    /**
+     * @brief Absolute normal stress on fault (positive in compression)
+     */
+    double sn_hat(std::size_t index, double sn) const { return -sn + p_[index].get<SnPre>(); }
+    /**
+     * @brief Absolute shear stress on fault.
+     *
+     * Includes radiation damping term. I.e. the returned value is equivalent to -sn_hat f(V, psi).
+     */
+    auto tau_hat(std::size_t index, std::array<double, TangentialComponents> const& tau,
+                 std::array<double, TangentialComponents> const& V) const {
+        return tau + p_[index].get<TauPre>() + p_[index].get<Eta>() * V;
+    }
+    auto S_init(std::size_t index) const { return p_[index].get<Sinit>(); }
+
+    auto slip_rate(std::size_t index, double sn,
+                   std::array<double, TangentialComponents> const& tau, double psi) const
+        -> std::array<double, TangentialComponents> {
+        auto eta = p_[index].get<Eta>();
+        auto tauAbsVec = tau + p_[index].get<TauPre>();
+        double snAbs = -sn + p_[index].get<SnPre>();
+        double tauAbs = norm(tauAbsVec);
+        double V = 0.0;
+        if (eta == 0.0) {
+            V = Finv(index, snAbs, tauAbs, psi);
+        } else {
+            if (snAbs <= 0.0) { /* Implies the fault is experiencing tension / opening */
+                snAbs = 0.0; /* Just to illustrate what we are doing */
+                /* Solve R(V) = T - sigma_n F(V,psi) - eta V with sigma_n = 0.0 */
+                V = tauAbs / eta;
+            } else {
+                double a = 0.0;
+                double b = tauAbs / eta;
+                if (a > b) {
+                    std::swap(a, b);
+                }
+                auto fF = [this, &index, &snAbs, &tauAbs, &psi, &eta](double V) {
+                    return tauAbs - this->F(index, snAbs, V, psi) - eta * V;
+                };
+                try {
+                    V = zeroIn(a, b, fF);
+                } catch (std::exception const&) {
+                    std::cout << "sigma_n = " << snAbs << std::endl
+                              << "|tau| = " << tauAbs << std::endl
+                              << "psi = " << psi << std::endl
+                              << "L = " << a << std::endl
+                              << "U = " << b << std::endl
+                              << "F(L) = " << fF(a) << std::endl
+                              << "F(U) = " << fF(b) << std::endl;
+                    throw;
+                }
+            }
+        }
+        return -(V / tauAbs) * tauAbsVec;
+    }
+
+    double state_rhs(std::size_t index, double V, double psi) const {
+        double myL = p_[index].get<L>();
+        return cp_.b * cp_.V0 / myL * (exp((cp_.f0 - psi) / cp_.b) - V / cp_.V0);
+    }
+
+    auto param_names() const {
+        auto names = std::vector<std::string>(4 + TangentialComponents);
+        char buf[100];
+
+        std::size_t i = 0;
+        names[i++] = "a";
+        names[i++] = "eta";
+        names[i++] = "L";
+        names[i++] = "sn_pre";
+        for (std::size_t t = 0; t < TangentialComponents; ++t) {
+            snprintf(buf, sizeof(buf), "tau_pre%lu", t);
+            names[i++] = buf;
+        }
+        return names;
+    }
+
+    template <typename VecT> void params(std::size_t index, VecT& result) const {
+        assert(result.shape(0) == 4 + TangentialComponents);
+        std::ptrdiff_t i = 0;
+        result(i++) = p_[index].get<A>();
+        result(i++) = p_[index].get<Eta>();
+        result(i++) = p_[index].get<L>();
+        result(i++) = p_[index].get<SnPre>();
+        auto const& tau_pre = p_[index].get<TauPre>();
+        for (auto const& t : tau_pre) {
+            result(i++) = t;
+        }
+    }
+
+protected:
+    double F(std::size_t index, double snAbs, double V, double psi) const {
+        auto a = p_[index].get<A>();
+        double e = exp(psi / a);
+        double f = a * asinh((V / (2.0 * cp_.V0)) * e);
+        return snAbs * f;
+    }
+
+    double Finv(std::size_t index, double snAbs, double tauAbs, double psi) const {
+        // We have
+        // V = 2 V_0 sinh(tauAbs / (a snAbs)) exp(-psi / a)
+        // substituting r = tauAbs / snAbs and sinh(x) = (exp(x) - exp(-x)) / 2 we obtain
+        // V = V_0 (exp((r - psi) / a) - exp(-(r + psi) / a))
+        auto a = p_[index].get<A>();
+        double r = tauAbs / snAbs;
+        return cp_.V0 * (exp((r - psi) / a) - exp(-(r + psi) / a));
+    }
+
+    ConstantParams cp_;
+
+    struct SnPre {
+        using type = double;
+    };
+    struct TauPre {
+        using type = std::array<double, TangentialComponents>;
+    };
+    struct A {
+        using type = double;
+    };
+    struct Eta {
+        using type = double;
+    };
+    struct L {
+        using type = double;
+    };
+    struct Vinit {
+        using type = std::array<double, TangentialComponents>;
+    };
+    struct Sinit {
+        using type = std::array<double, TangentialComponents>;
+    };
+    mneme::MultiStorage<mneme::DataLayout::SoA, SnPre, TauPre, A, Eta, L, Vinit, Sinit> p_;
+};
+
+} // namespace tndm
+
+#endif // DIETERICHRUINAAGING_20201027_H

--- a/app/localoperator/DieterichRuinaBase.h
+++ b/app/localoperator/DieterichRuinaBase.h
@@ -1,5 +1,5 @@
-#ifndef DIETERICHRUINAAGEING_20201027_H
-#define DIETERICHRUINAAGEING_20201027_H
+#ifndef DIETERICHRUINABASE_20241105_H
+#define DIETERICHRUINABASE_20241105_H
 
 #include "config.h"
 
@@ -17,7 +17,7 @@
 
 namespace tndm {
 
-class DieterichRuinaAgeing {
+class DieterichRuinaBase {
 public:
     static constexpr std::size_t TangentialComponents = DomainDimension - 1u;
 
@@ -79,8 +79,8 @@ public:
     auto S_init(std::size_t index) const { return p_[index].get<Sinit>(); }
 
     auto slip_rate(std::size_t index, double sn,
-                   std::array<double, TangentialComponents> const& tau, double psi) const
-        -> std::array<double, TangentialComponents> {
+                   std::array<double, TangentialComponents> const& tau,
+                   double psi) const -> std::array<double, TangentialComponents> {
         auto eta = p_[index].get<Eta>();
         auto tauAbsVec = tau + p_[index].get<TauPre>();
         double snAbs = -sn + p_[index].get<SnPre>();
@@ -90,7 +90,7 @@ public:
             V = Finv(index, snAbs, tauAbs, psi);
         } else {
             if (snAbs <= 0.0) { /* Implies the fault is experiencing tension / opening */
-                snAbs = 0.0; /* Just to illustrate what we are doing */
+                snAbs = 0.0;    /* Just to illustrate what we are doing */
                 /* Solve R(V) = T - sigma_n F(V,psi) - eta V with sigma_n = 0.0 */
                 V = tauAbs / eta;
             } else {
@@ -118,11 +118,7 @@ public:
         }
         return -(V / tauAbs) * tauAbsVec;
     }
-
-    double state_rhs(std::size_t index, double V, double psi) const {
-        double myL = p_[index].get<L>();
-        return cp_.b * cp_.V0 / myL * (exp((cp_.f0 - psi) / cp_.b) - V / cp_.V0);
-    }
+    virtual double state_rhs(std::size_t index, double V, double psi) const = 0;
 
     auto param_names() const {
         auto names = std::vector<std::string>(4 + TangentialComponents);
@@ -199,4 +195,4 @@ protected:
 
 } // namespace tndm
 
-#endif // DIETERICHRUINAAGEING_20201027_H
+#endif // DIETERICHRUINABASE_20241105_H

--- a/app/localoperator/DieterichRuinaSlip.h
+++ b/app/localoperator/DieterichRuinaSlip.h
@@ -1,0 +1,31 @@
+#ifndef DIETERICHRUINASLIP_20240131_H
+#define DIETERICHRUINASLIP_20240131_H
+
+#include "config.h"
+
+#include "geometry/Vector.h"
+#include "tensor/Tensor.h"
+#include "util/Zero.h"
+#include "localoperator/DieterichRuinaAgeing.h"
+
+#include "mneme/storage.hpp"
+
+#include <algorithm>
+#include <cassert>
+#include <cstddef>
+#include <exception>
+#include <iostream>
+
+namespace tndm {
+
+class DieterichRuinaSlip : public DieterichRuinaAgeing {
+public:
+    double state_rhs(std::size_t index, double V, double psi) const {
+        double myL = p_[index].get<L>();
+        return - cp_.b * V / myL * (log(V / cp_.V0) + (psi - cp_.f0) / cp_.b); // Slip law
+    }
+};
+
+} // namespace tndm
+
+#endif // DIETERICHRUINASLIP_20240131_H

--- a/app/localoperator/DieterichRuinaSlip.h
+++ b/app/localoperator/DieterichRuinaSlip.h
@@ -6,7 +6,7 @@
 #include "geometry/Vector.h"
 #include "tensor/Tensor.h"
 #include "util/Zero.h"
-#include "localoperator/DieterichRuinaAgeing.h"
+#include "localoperator/DieterichRuinaAging.h"
 
 #include "mneme/storage.hpp"
 
@@ -18,7 +18,7 @@
 
 namespace tndm {
 
-class DieterichRuinaSlip : public DieterichRuinaAgeing {
+class DieterichRuinaSlip : public DieterichRuinaAging {
 public:
     double state_rhs(std::size_t index, double V, double psi) const {
         double myL = p_[index].get<L>();

--- a/app/localoperator/DieterichRuinaSlip.h
+++ b/app/localoperator/DieterichRuinaSlip.h
@@ -4,9 +4,9 @@
 #include "config.h"
 
 #include "geometry/Vector.h"
+#include "localoperator/DieterichRuinaBase.h"
 #include "tensor/Tensor.h"
 #include "util/Zero.h"
-#include "localoperator/DieterichRuinaAging.h"
 
 #include "mneme/storage.hpp"
 
@@ -18,11 +18,11 @@
 
 namespace tndm {
 
-class DieterichRuinaSlip : public DieterichRuinaAging {
+class DieterichRuinaSlip : public DieterichRuinaBase {
 public:
-    double state_rhs(std::size_t index, double V, double psi) const {
+    double state_rhs(std::size_t index, double V, double psi) const override {
         double myL = p_[index].get<L>();
-        return - cp_.b * V / myL * (log(V / cp_.V0) + (psi - cp_.f0) / cp_.b); // Slip law
+        return -cp_.b * V / myL * (log(V / cp_.V0) + (psi - cp_.f0) / cp_.b); // Slip law
     }
 };
 

--- a/app/localoperator/RateAndState.h
+++ b/app/localoperator/RateAndState.h
@@ -98,7 +98,6 @@ private:
         return (*delta_sn_)(xt)[0];
     }
 
-
     Law law_;
     std::optional<source_fun_t> source_;
     std::optional<delta_tau_fun_t> delta_tau_;
@@ -157,9 +156,9 @@ double RateAndState<Law>::rhs(double time, std::size_t faultNo,
     auto t_mat = traction_mat(traction);
     for (std::size_t node = 0; node < nbf; ++node) {
         auto sn = t_mat(node, 0);
-	if (delta_sn_) {
-            sn = sn + get_delta_sn(time, faultNo, node);
-	}
+        if (delta_sn_) {
+                sn = sn + get_delta_sn(time, faultNo, node);
+        }
         auto psi = s_mat(node, PsiIndex);
         auto tau = get_tau(node, t_mat);
         if (delta_tau_) {
@@ -218,9 +217,9 @@ void RateAndState<Law>::state(double time, std::size_t faultNo,
     std::size_t index = faultNo * nbf;
     for (std::size_t node = 0; node < nbf; ++node) {
         auto sn = t_mat(node, 0);
-	if (delta_sn_) {
-            sn = sn + get_delta_sn(time, faultNo, node);
-	}
+        if (delta_sn_) {
+                sn = sn + get_delta_sn(time, faultNo, node);
+        }
         auto tau = get_tau(node, t_mat);
         if (delta_tau_) {
             tau = tau + get_delta_tau(time, faultNo, node);

--- a/app/localoperator/RateAndState.h
+++ b/app/localoperator/RateAndState.h
@@ -157,7 +157,7 @@ double RateAndState<Law>::rhs(double time, std::size_t faultNo,
     for (std::size_t node = 0; node < nbf; ++node) {
         auto sn = t_mat(node, 0);
         if (delta_sn_) {
-                sn = sn + get_delta_sn(time, faultNo, node);
+            sn = sn + get_delta_sn(time, faultNo, node);
         }
         auto psi = s_mat(node, PsiIndex);
         auto tau = get_tau(node, t_mat);
@@ -218,7 +218,7 @@ void RateAndState<Law>::state(double time, std::size_t faultNo,
     for (std::size_t node = 0; node < nbf; ++node) {
         auto sn = t_mat(node, 0);
         if (delta_sn_) {
-                sn = sn + get_delta_sn(time, faultNo, node);
+            sn = sn + get_delta_sn(time, faultNo, node);
         }
         auto tau = get_tau(node, t_mat);
         if (delta_tau_) {

--- a/app/tandem/Context.h
+++ b/app/tandem/Context.h
@@ -8,6 +8,7 @@
 #include "form/FrictionOperator.h"
 #include "form/SeasQDOperator.h"
 #include "localoperator/DieterichRuinaAgeing.h"
+#include "localoperator/DieterichRuinaSlip.h"
 #include "localoperator/Elasticity.h"
 #include "localoperator/Poisson.h"
 #include "localoperator/RateAndState.h"
@@ -48,12 +49,16 @@ template <typename Type> class Context : public ContextBase {
 public:
     using adapter_t = AdapterOperator<Type>;
     using dg_t = DGOperator<Type>;
-    using friction_lop_t = RateAndState<DieterichRuinaAgeing>;
+    #if AGING_LAW
+        using friction_lop_t = RateAndState<DieterichRuinaAgeing>;
+    #elif SLIP_LAW
+        using friction_lop_t = RateAndState<DieterichRuinaSlip>;
+    #endif
     using friction_t = FrictionOperator<friction_lop_t>;
 
     Context(LocalSimplexMesh<DomainDimension> const& mesh,
             std::unique_ptr<SeasScenario<Type>> seas_sc,
-            std::unique_ptr<DieterichRuinaAgeingScenario> friction_sc,
+            std::unique_ptr<DieterichRuinaScenario> friction_sc,
             std::array<double, DomainDimension> up, std::array<double, DomainDimension> ref_normal)
         : ContextBase(mesh, seas_sc->transform()), scenario(std::move(seas_sc)),
           friction_scenario(std::move(friction_sc)),
@@ -113,7 +118,7 @@ public:
     }
 
     std::unique_ptr<SeasScenario<Type>> scenario;
-    std::unique_ptr<DieterichRuinaAgeingScenario> friction_scenario;
+    std::unique_ptr<DieterichRuinaScenario> friction_scenario;
     std::shared_ptr<Type> dg_lop;
 
 private:

--- a/app/tandem/Context.h
+++ b/app/tandem/Context.h
@@ -7,7 +7,7 @@
 #include "form/AdapterOperator.h"
 #include "form/FrictionOperator.h"
 #include "form/SeasQDOperator.h"
-#include "localoperator/DieterichRuinaAgeing.h"
+#include "localoperator/DieterichRuinaAging.h"
 #include "localoperator/DieterichRuinaSlip.h"
 #include "localoperator/Elasticity.h"
 #include "localoperator/Poisson.h"
@@ -49,9 +49,9 @@ template <typename Type> class Context : public ContextBase {
 public:
     using adapter_t = AdapterOperator<Type>;
     using dg_t = DGOperator<Type>;
-    #if AGING_LAW
-        using friction_lop_t = RateAndState<DieterichRuinaAgeing>;
-    #elif SLIP_LAW
+    #if defined(DR_AGING_LAW)
+        using friction_lop_t = RateAndState<DieterichRuinaAging>;
+    #elif defined(DR_SLIP_LAW)
         using friction_lop_t = RateAndState<DieterichRuinaSlip>;
     #endif
     using friction_t = FrictionOperator<friction_lop_t>;

--- a/app/tandem/Context.h
+++ b/app/tandem/Context.h
@@ -7,8 +7,7 @@
 #include "form/AdapterOperator.h"
 #include "form/FrictionOperator.h"
 #include "form/SeasQDOperator.h"
-#include "localoperator/DieterichRuinaAging.h"
-#include "localoperator/DieterichRuinaSlip.h"
+#include "localoperator/DieterichRuinaBase.h"
 #include "localoperator/Elasticity.h"
 #include "localoperator/Poisson.h"
 #include "localoperator/RateAndState.h"
@@ -49,11 +48,12 @@ template <typename Type> class Context : public ContextBase {
 public:
     using adapter_t = AdapterOperator<Type>;
     using dg_t = DGOperator<Type>;
-    #if defined(DR_AGING_LAW)
-        using friction_lop_t = RateAndState<DieterichRuinaAging>;
-    #elif defined(DR_SLIP_LAW)
-        using friction_lop_t = RateAndState<DieterichRuinaSlip>;
-    #endif
+
+#if defined(DR_AGING_LAW)
+    using friction_lop_t = RateAndState<DieterichRuinaAging>;
+#elif defined(DR_SLIP_LAW)
+    using friction_lop_t = RateAndState<DieterichRuinaSlip>;
+#endif
     using friction_t = FrictionOperator<friction_lop_t>;
 
     Context(LocalSimplexMesh<DomainDimension> const& mesh,

--- a/app/tandem/FrictionConfig.h
+++ b/app/tandem/FrictionConfig.h
@@ -2,7 +2,7 @@
 #define FRICTIONCONFIG_20201027_H
 
 #include "config.h"
-#include "localoperator/DieterichRuinaAgeing.h"
+#include "localoperator/DieterichRuinaAging.h"
 #include "localoperator/DieterichRuinaSlip.h"
 #include "localoperator/RateAndStateBase.h"
 #include "tandem/SeasSolution.h"
@@ -97,11 +97,7 @@ public:
     auto const& constant_params() const { return cp_; }
     auto param_fun() const {
         return [this](std::array<double, DomainDimension> const& x) {
-            #if AGING_LAW
-                DieterichRuinaAgeing::Params p;
-            #elif SLIP_LAW
-                DieterichRuinaSlip::Params p;
-            #endif
+            DieterichRuinaAging::Params p;
             p.a = this->a_(x)[0];
             p.eta = this->eta_(x)[0];
             p.L = this->L_(x)[0];
@@ -125,11 +121,7 @@ public:
     }
 
 protected:
-    #if AGING_LAW
-        DieterichRuinaAgeing::ConstantParams cp_;
-    #elif SLIP_LAW
-        DieterichRuinaSlip::ConstantParams cp_;
-    #endif
+    DieterichRuinaAging::ConstantParams cp_;
     LuaLib lib_;
     functional_t<DomainDimension> a_, eta_, L_;
     functional_t<DomainDimension> sn_pre_ =

--- a/app/tandem/FrictionConfig.h
+++ b/app/tandem/FrictionConfig.h
@@ -3,6 +3,7 @@
 
 #include "config.h"
 #include "localoperator/DieterichRuinaAgeing.h"
+#include "localoperator/DieterichRuinaSlip.h"
 #include "localoperator/RateAndStateBase.h"
 #include "tandem/SeasSolution.h"
 
@@ -18,13 +19,13 @@
 
 namespace tndm {
 
-class DieterichRuinaAgeingScenario {
+class DieterichRuinaScenario {
 public:
     template <std::size_t D>
     using functional_t = std::function<std::array<double, 1>(std::array<double, D> const&)>;
     template <std::size_t D>
     using vector_functional_t =
-        std::function<std::array<double, DieterichRuinaAgeing::TangentialComponents>(
+        std::function<std::array<double, RateAndStateBase::TangentialComponents>(
             std::array<double, D> const&)>;
     static constexpr std::size_t NumQuantities = RateAndStateBase::NumQuantities;
 
@@ -43,7 +44,7 @@ public:
     constexpr static char DeltaSn[] = "delta_sn";
     constexpr static char FaultSolution[] = "fault_solution";
 
-    DieterichRuinaAgeingScenario(std::string const& lib, std::string const& scenario) {
+    DieterichRuinaScenario(std::string const& lib, std::string const& scenario) {
         lib_.loadFile(lib);
 
         a_ = lib_.getMemberFunction<DomainDimension, 1>(scenario, A);
@@ -54,15 +55,15 @@ public:
         }
         if (lib_.hasMember(scenario, TauPre)) {
             tau_pre_ =
-                lib_.getMemberFunction<DomainDimension, DieterichRuinaAgeing::TangentialComponents>(
+                lib_.getMemberFunction<DomainDimension, RateAndStateBase::TangentialComponents>(
                     scenario, TauPre);
         }
         Vinit_ =
-            lib_.getMemberFunction<DomainDimension, DieterichRuinaAgeing::TangentialComponents>(
+            lib_.getMemberFunction<DomainDimension, RateAndStateBase::TangentialComponents>(
                 scenario, Vinit);
         if (lib_.hasMember(scenario, Sinit)) {
             Sinit_ =
-                lib_.getMemberFunction<DomainDimension, DieterichRuinaAgeing::TangentialComponents>(
+                lib_.getMemberFunction<DomainDimension, RateAndStateBase::TangentialComponents>(
                     scenario, Sinit);
         }
         if (lib_.hasMember(scenario, Source)) {
@@ -72,7 +73,7 @@ public:
         if (lib_.hasMember(scenario, DeltaTau)) {
             delta_tau_ = std::make_optional(
                 lib_.getMemberFunction<DomainDimension + 1,
-                                       DieterichRuinaAgeing::TangentialComponents>(scenario,
+                                       RateAndStateBase::TangentialComponents>(scenario,
                                                                                    DeltaTau));
         }
         if (lib_.hasMember(scenario, DeltaSn)) {
@@ -96,7 +97,11 @@ public:
     auto const& constant_params() const { return cp_; }
     auto param_fun() const {
         return [this](std::array<double, DomainDimension> const& x) {
-            DieterichRuinaAgeing::Params p;
+            #if AGING_LAW
+                DieterichRuinaAgeing::Params p;
+            #elif SLIP_LAW
+                DieterichRuinaSlip::Params p;
+            #endif
             p.a = this->a_(x)[0];
             p.eta = this->eta_(x)[0];
             p.L = this->L_(x)[0];
@@ -120,16 +125,20 @@ public:
     }
 
 protected:
-    DieterichRuinaAgeing::ConstantParams cp_;
+    #if AGING_LAW
+        DieterichRuinaAgeing::ConstantParams cp_;
+    #elif SLIP_LAW
+        DieterichRuinaSlip::ConstantParams cp_;
+    #endif
     LuaLib lib_;
     functional_t<DomainDimension> a_, eta_, L_;
     functional_t<DomainDimension> sn_pre_ =
         [](std::array<double, DomainDimension> const& x) -> std::array<double, 1> { return {0.0}; };
     vector_functional_t<DomainDimension> tau_pre_ = [](std::array<double, DomainDimension> const& x)
-        -> std::array<double, DieterichRuinaAgeing::TangentialComponents> { return {}; };
+        -> std::array<double, RateAndStateBase::TangentialComponents> { return {}; };
     vector_functional_t<DomainDimension> Vinit_;
     vector_functional_t<DomainDimension> Sinit_ = [](std::array<double, DomainDimension> const& x)
-        -> std::array<double, DieterichRuinaAgeing::TangentialComponents> { return {}; };
+        -> std::array<double, RateAndStateBase::TangentialComponents> { return {}; };
     std::optional<functional_t<DomainDimension + 1>> source_ = std::nullopt;
     std::optional<vector_functional_t<DomainDimension + 1>> delta_tau_ = std::nullopt;
     std::optional<functional_t<DomainDimension + 1>> delta_sn_ = std::nullopt;

--- a/app/tandem/FrictionConfig.h
+++ b/app/tandem/FrictionConfig.h
@@ -2,8 +2,7 @@
 #define FRICTIONCONFIG_20201027_H
 
 #include "config.h"
-#include "localoperator/DieterichRuinaAging.h"
-#include "localoperator/DieterichRuinaSlip.h"
+#include "localoperator/DieterichRuinaBase.h"
 #include "localoperator/RateAndStateBase.h"
 #include "tandem/SeasSolution.h"
 
@@ -58,9 +57,8 @@ public:
                 lib_.getMemberFunction<DomainDimension, RateAndStateBase::TangentialComponents>(
                     scenario, TauPre);
         }
-        Vinit_ =
-            lib_.getMemberFunction<DomainDimension, RateAndStateBase::TangentialComponents>(
-                scenario, Vinit);
+        Vinit_ = lib_.getMemberFunction<DomainDimension, RateAndStateBase::TangentialComponents>(
+            scenario, Vinit);
         if (lib_.hasMember(scenario, Sinit)) {
             Sinit_ =
                 lib_.getMemberFunction<DomainDimension, RateAndStateBase::TangentialComponents>(
@@ -72,15 +70,12 @@ public:
         }
         if (lib_.hasMember(scenario, DeltaTau)) {
             delta_tau_ = std::make_optional(
-                lib_.getMemberFunction<DomainDimension + 1,
-                                       RateAndStateBase::TangentialComponents>(scenario,
-                                                                                   DeltaTau));
+                lib_.getMemberFunction<DomainDimension + 1, RateAndStateBase::TangentialComponents>(
+                    scenario, DeltaTau));
         }
         if (lib_.hasMember(scenario, DeltaSn)) {
             delta_sn_ = std::make_optional(
-                lib_.getMemberFunction<DomainDimension + 1,
-                                       1>(scenario,
-                                                                                   DeltaSn));
+                lib_.getMemberFunction<DomainDimension + 1, 1>(scenario, DeltaSn));
         }
 
         cp_.V0 = lib_.getMemberConstant(scenario, V0);
@@ -97,7 +92,7 @@ public:
     auto const& constant_params() const { return cp_; }
     auto param_fun() const {
         return [this](std::array<double, DomainDimension> const& x) {
-            DieterichRuinaAging::Params p;
+            DieterichRuinaBase::Params p;
             p.a = this->a_(x)[0];
             p.eta = this->eta_(x)[0];
             p.L = this->L_(x)[0];
@@ -121,7 +116,7 @@ public:
     }
 
 protected:
-    DieterichRuinaAging::ConstantParams cp_;
+    DieterichRuinaBase::ConstantParams cp_;
     LuaLib lib_;
     functional_t<DomainDimension> a_, eta_, L_;
     functional_t<DomainDimension> sn_pre_ =

--- a/app/tandem/SEAS.cpp
+++ b/app/tandem/SEAS.cpp
@@ -13,6 +13,7 @@
 #include "form/VolumeFunctionalFactory.h"
 #include "localoperator/Adapter.h"
 #include "localoperator/DieterichRuinaAgeing.h"
+#include "localoperator/DieterichRuinaSlip.h"
 #include "localoperator/Elasticity.h"
 #include "localoperator/Poisson.h"
 #include "localoperator/RateAndState.h"
@@ -55,7 +56,7 @@ template <typename Type>
 auto make_context(LocalSimplexMesh<DomainDimension> const& mesh, Config const& cfg) {
     return std::make_unique<seas::Context<Type>>(
         mesh, std::make_unique<SeasScenario<Type>>(cfg.lib, cfg.scenario),
-        std::make_unique<DieterichRuinaAgeingScenario>(cfg.lib, cfg.scenario), cfg.up,
+        std::make_unique<DieterichRuinaScenario>(cfg.lib, cfg.scenario), cfg.up,
         cfg.ref_normal);
 }
 

--- a/app/tandem/SEAS.cpp
+++ b/app/tandem/SEAS.cpp
@@ -12,7 +12,7 @@
 #include "form/SeasQDOperator.h"
 #include "form/VolumeFunctionalFactory.h"
 #include "localoperator/Adapter.h"
-#include "localoperator/DieterichRuinaAgeing.h"
+#include "localoperator/DieterichRuinaAging.h"
 #include "localoperator/DieterichRuinaSlip.h"
 #include "localoperator/Elasticity.h"
 #include "localoperator/Poisson.h"


### PR DESCRIPTION
This feature allows users to choose between Aging law and Slip law as their state variable evolution law during the compilation. The compilation argument `FRICTION_LAW` takes either `dieterich_ruina_aging` or `dieterich_ruina_slip`, where `dieterich_ruina_aging` is the default.

Syntax E.g.:
`cmake $PATH_TO_TANDEM -DPOLYNOMIAL_DEGREE=6 -DDOMAIN_DIMENSION=2 -DFRICTION_LAW=dieterich_ruina_slip`
