### PR TITLE
Changing the velocity root-finding 

### DIFF
--- a/app/localoperator/DieterichRuinaAgeing.h
+++ b/app/localoperator/DieterichRuinaAgeing.h
@@ -80,8 +80,7 @@ public:
 
     auto slip_rate(std::size_t index, double sn,
                    std::array<double, TangentialComponents> const& tau, double psi) const
-        -> std::array<double, TangentialComponents> 
-    {
+        -> std::array<double, TangentialComponents> {
         auto eta = p_[index].get<Eta>();
         auto tauAbsVec = tau + p_[index].get<TauPre>();
         double snAbs = -sn + p_[index].get<SnPre>();
@@ -90,52 +89,40 @@ public:
         double a = -32;
         double a_min = std::log10(std::nextafter(0, INFINITY));
         double b;
-        if (eta == 0.0)
-        {
+        if (eta == 0.0) {
             V = Finv(index, snAbs, tauAbs, psi);
-        }
-        else
-        {
-            if (snAbs <= 0.0)
-            { /* Implies the fault is experiencing tension / opening */
-                snAbs = 0.0; /* Just to illustrate what we are doing */
+        } else {
+            if (snAbs <= 0.0) { /* Implies the fault is experiencing tension / opening */
+                snAbs = 0.0;    /* Just to illustrate what we are doing */
                 /* Solve R(V) = T - sigma_n F(V,psi) - eta V with sigma_n = 0.0 */
                 V = tauAbs / eta;
-            }
-            else
-            {
+            } else {
                 b = std::log10(tauAbs / eta);
-                auto fF = [this, &index, &snAbs, &tauAbs, &psi, &eta](double Ve)
-                {
-                    return tauAbs - this->F(index, snAbs, std::pow(10.0,Ve), psi) - eta * std::pow(10.0,Ve);
+                auto fF = [this, &index, &snAbs, &tauAbs, &psi, &eta](double Ve) {
+                    return tauAbs - this->F(index, snAbs, std::pow(10.0, Ve), psi) -
+                           eta * std::pow(10.0, Ve);
                 };
-                try
-                {
+                try {
                     auto Ve = zeroIn(a, b, fF);
                     V = std::pow(10.0, Ve);
-                }
-                catch (std::exception const&)
-                {
-                    try
-                    {
+                } catch (std::exception const&) {
+                    try {
                         auto Ve = zeroIn(a_min, b, fF);
                         V = std::pow(10.0, Ve);
-                    }
-                    catch(std::exception const&)
-                    {
+                    } catch (std::exception const&) {
                         std::cout << "sigma_n = " << snAbs << std::endl
-                            << "|tau| = " << tauAbs << std::endl
-                            << "psi = " << psi << std::endl
-                            << "L = " << a << std::endl
-                            << "U = " << b << std::endl
-                            << "F(L) = " << fF(a) << std::endl
-                            << "F(U) = " << fF(b) << std::endl;
+                                  << "|tau| = " << tauAbs << std::endl
+                                  << "psi = " << psi << std::endl
+                                  << "L = " << a << std::endl
+                                  << "U = " << b << std::endl
+                                  << "F(L) = " << fF(a) << std::endl
+                                  << "F(U) = " << fF(b) << std::endl;
                         throw;
                     }
                 }
             }
         }
-    return -(V / tauAbs) * tauAbsVec;
+        return -(V / tauAbs) * tauAbsVec;
     }
 
     double state_rhs(std::size_t index, double V, double psi) const {

--- a/app/localoperator/DieterichRuinaAgeing.h
+++ b/app/localoperator/DieterichRuinaAgeing.h
@@ -99,19 +99,20 @@ public:
                 if (a > b) {
                     std::swap(a, b);
                 }
-                auto fF = [this, &index, &snAbs, &tauAbs, &psi, &eta](double V) {
-                    return tauAbs - this->F(index, snAbs, V, psi) - eta * V;
+                auto fF = [this, &index, &snAbs, &tauAbs, &psi, &eta](double Ve) {
+                    return tauAbs - this->F(index, snAbs, std::pow(10.0,Ve), psi) - eta * std::pow(10.0,Ve);
                 };
                 try {
-                    V = zeroIn(a, b, fF);
+                    auto Ve = zeroIn(-216, std::log10(b), fF);
+                    V = std::pow(10.0,Ve);
                 } catch (std::exception const&) {
                     std::cout << "sigma_n = " << snAbs << std::endl
                               << "|tau| = " << tauAbs << std::endl
                               << "psi = " << psi << std::endl
                               << "L = " << a << std::endl
                               << "U = " << b << std::endl
-                              << "F(L) = " << fF(a) << std::endl
-                              << "F(U) = " << fF(b) << std::endl;
+                              << "F(L) = " << fF(-216) << std::endl
+                              << "F(U) = " << fF(std::log10(b)) << std::endl;
                     throw;
                 }
             }

--- a/app/localoperator/DieterichRuinaAgeing.h
+++ b/app/localoperator/DieterichRuinaAgeing.h
@@ -87,7 +87,7 @@ public:
         double tauAbs = norm(tauAbsVec);
         double V = 0.0;
         double a = -32;
-        double a_min = std::log10(std::nextafter(0, INFINITY));
+        double a_min = std::log10(std::nextafter(0, 1));
         double b;
         if (eta == 0.0) {
             V = Finv(index, snAbs, tauAbs, psi);

--- a/app/localoperator/DieterichRuinaAgeing.h
+++ b/app/localoperator/DieterichRuinaAgeing.h
@@ -86,38 +86,54 @@ public:
         double snAbs = -sn + p_[index].get<SnPre>();
         double tauAbs = norm(tauAbsVec);
         double V = 0.0;
-        if (eta == 0.0) {
+        double max_xi = -std::pow(2, 8);
+        double a, b;
+        if (eta == 0.0)
+        {
             V = Finv(index, snAbs, tauAbs, psi);
-        } else {
-            if (snAbs <= 0.0) { /* Implies the fault is experiencing tension / opening */
+        }
+        else
+        {
+            if (snAbs <= 0.0)
+            { /* Implies the fault is experiencing tension / opening */
                 snAbs = 0.0; /* Just to illustrate what we are doing */
                 /* Solve R(V) = T - sigma_n F(V,psi) - eta V with sigma_n = 0.0 */
                 V = tauAbs / eta;
-            } else {
-                double a = 0.0;
-                double b = tauAbs / eta;
-                if (a > b) {
-                    std::swap(a, b);
-                }
-                auto fF = [this, &index, &snAbs, &tauAbs, &psi, &eta](double Ve) {
+            }
+            else
+            {
+                b = std::log10(tauAbs / eta);
+                auto fF = [this, &index, &snAbs, &tauAbs, &psi, &eta](double Ve)
+                {
                     return tauAbs - this->F(index, snAbs, std::pow(10.0,Ve), psi) - eta * std::pow(10.0,Ve);
                 };
-                try {
-                    auto Ve = zeroIn(-216, std::log10(b), fF);
-                    V = std::pow(10.0,Ve);
-                } catch (std::exception const&) {
-                    std::cout << "sigma_n = " << snAbs << std::endl
-                              << "|tau| = " << tauAbs << std::endl
-                              << "psi = " << psi << std::endl
-                              << "L = " << a << std::endl
-                              << "U = " << b << std::endl
-                              << "F(L) = " << fF(-216) << std::endl
-                              << "F(U) = " << fF(std::log10(b)) << std::endl;
-                    throw;
-                }
+                for (int xi = 5; xi < 9; ++xi)
+                {
+                    try
+                    {
+                        a = -std::pow(2.0, xi);
+                        auto Ve = zeroIn(a, b, fF);
+                        V = std::pow(10.0, Ve);
+                        break;
+                    }
+                    catch (std::exception const&)
+                    {
+                        if (a == max_xi)
+                        {
+                            std::cout << "sigma_n = " << snAbs << std::endl
+                                << "|tau| = " << tauAbs << std::endl
+                                << "psi = " << psi << std::endl
+                                << "L = " << a << std::endl
+                                << "U = " << b << std::endl
+                                << "F(L) = " << fF(a) << std::endl
+                                << "F(U) = " << fF(b) << std::endl;
+                            throw;
+                        } 
+                    }
             }
         }
-        return -(V / tauAbs) * tauAbsVec;
+    }
+    return -(V / tauAbs) * tauAbsVec;
     }
 
     double state_rhs(std::size_t index, double V, double psi) const {

--- a/app/localoperator/DieterichRuinaAgeing.h
+++ b/app/localoperator/DieterichRuinaAgeing.h
@@ -107,7 +107,7 @@ public:
                 {
                     return tauAbs - this->F(index, snAbs, std::pow(10.0,Ve), psi) - eta * std::pow(10.0,Ve);
                 };
-                for (int xi = 5; xi < max_xi + 1; ++xi)
+                for (int xi = 5; xi <= max_xi; ++xi)
                 {
                     try
                     {

--- a/app/localoperator/DieterichRuinaAgeing.h
+++ b/app/localoperator/DieterichRuinaAgeing.h
@@ -86,7 +86,7 @@ public:
         double snAbs = -sn + p_[index].get<SnPre>();
         double tauAbs = norm(tauAbsVec);
         double V = 0.0;
-        double max_xi = -std::pow(2, 8);
+        int max_xi = 8;
         double a, b;
         if (eta == 0.0)
         {
@@ -107,7 +107,7 @@ public:
                 {
                     return tauAbs - this->F(index, snAbs, std::pow(10.0,Ve), psi) - eta * std::pow(10.0,Ve);
                 };
-                for (int xi = 5; xi < 9; ++xi)
+                for (int xi = 5; xi < max_xi + 1; ++xi)
                 {
                     try
                     {
@@ -118,7 +118,7 @@ public:
                     }
                     catch (std::exception const&)
                     {
-                        if (a == max_xi)
+                        if (xi == max_xi)
                         {
                             std::cout << "sigma_n = " << snAbs << std::endl
                                 << "|tau| = " << tauAbs << std::endl


### PR DESCRIPTION
Changing the velocity root-finding, line 13 of algorithm 1 in the tandem paper.
Instead of searching for $V$ S.T
$\sigma_n F(V, \psi_{k}^{e}) + \eta V - T = 0$
searching for $\xi$ S.T
$V = 10^{\xi}$

It was tested against bp1 bp3, and my own SSEs simulations and it shows ~40% improvement in run time when running with green functions. 

bp1:
new root-finding run time: 554.237
main run time: 888.816
<img width="612" alt="bp1" src="https://github.com/user-attachments/assets/02bccd3b-a588-4647-a69b-67b9ed02d94a">


bp3:
new root-finding run time: 4099.94
main run time: 6373.47
<img width="612" alt="bp3" src="https://github.com/user-attachments/assets/3f78a657-3ab9-4b4f-a2d3-23c4dd257de4">

Is more testing needed before merging into main? If so, what would you like to test?

