### PR TITLE
add dimension, polynomial degree and min order or quad rule in banner

### DIFF
--- a/app/common/Banner.cpp
+++ b/app/common/Banner.cpp
@@ -37,6 +37,9 @@ void Banner::print_centered(std::ostream& out, std::string_view str, std::size_t
 
 void Banner::print_version(std::ostream& out) {
     print_centered(out, "tandem version " + std::string(VersionString));
+    print_centered(out, "Domain dimension " + std::to_string(DomainDimension));
+    print_centered(out, "polynomial degree " + std::to_string(PolynomialDegree));
+    print_centered(out, "Minimum order of quadrature rule " + std::to_string(MinQuadOrder()));
 }
 
 void Banner::print_stack_limit(std::ostream& out) {

--- a/app/common/Banner.cpp
+++ b/app/common/Banner.cpp
@@ -69,7 +69,9 @@ void Banner::print_stack_limit(std::ostream& out) {
     }
 }
 
-void Banner::print_affinity(std::ostream& out, Affinity const& affinity) {
+void Banner::print_affinity(std::ostream& out, Affinity const& affinity,
+                            std::string_view node_mask) {
+    // Print individual worker affinity
     print_centered(out, "Worker affinity");
     auto mask = affinity.to_string(affinity.worker_mask());
     auto mask_view = std::string_view(mask);
@@ -82,16 +84,22 @@ void Banner::print_affinity(std::ostream& out, Affinity const& affinity) {
     for (int i = 0; i < num_lines; ++i) {
         print_centered(out, mask_view.substr(i * line_width, line_width), line_width);
     }
+    // Print node-wide worker affinity
+    print_centered(out, "Worker affinity on node");
+    auto node_mask_view = std::string_view(node_mask);
+    for (int i = 0; i < num_lines; ++i) {
+        print_centered(out, node_mask_view.substr(i * line_width, line_width), line_width);
+    }
 }
 
-void Banner::standard(std::ostream& out, Affinity const& affinity) {
+void Banner::standard(std::ostream& out, Affinity const& affinity, std::string_view node_mask) {
     print_logo(out);
     out << std::endl;
     print_version(out);
     out << std::endl;
     print_stack_limit(out);
     out << std::endl;
-    print_affinity(out, affinity);
+    print_affinity(out, affinity, node_mask);
     out << std::endl << std::endl;
 }
 

--- a/app/common/Banner.h
+++ b/app/common/Banner.h
@@ -30,9 +30,10 @@ public:
                                std::size_t length = std::string_view::npos);
     static void print_version(std::ostream& out);
     static void print_stack_limit(std::ostream& out);
-    static void print_affinity(std::ostream& out, Affinity const& affinity);
+    static void print_affinity(std::ostream& out, Affinity const& affinity,
+                               std::string_view node_mask);
 
-    static void standard(std::ostream& out, Affinity const& affinity);
+    static void standard(std::ostream& out, Affinity const& affinity, std::string_view node_mask);
 
 private:
     static constexpr std::size_t logo_width();

--- a/app/static.cpp
+++ b/app/static.cpp
@@ -322,8 +322,9 @@ int main(int argc, char** argv) {
     MPI_Comm_rank(PETSC_COMM_WORLD, &rank);
     MPI_Comm_size(PETSC_COMM_WORLD, &procs);
 
+    auto node_mask = affinity.to_string(affinity.worker_mask_on_node(PETSC_COMM_WORLD));
     if (rank == 0) {
-        Banner::standard(std::cout, affinity);
+        Banner::standard(std::cout, affinity, node_mask);
     }
 
     std::unique_ptr<GlobalSimplexMesh<DomainDimension>> globalMesh;

--- a/app/tandem.cpp
+++ b/app/tandem.cpp
@@ -77,8 +77,9 @@ int main(int argc, char** argv) {
     MPI_Comm_rank(PETSC_COMM_WORLD, &rank);
     MPI_Comm_size(PETSC_COMM_WORLD, &procs);
 
+    auto node_mask = affinity.to_string(affinity.worker_mask_on_node(PETSC_COMM_WORLD));
     if (rank == 0) {
-        Banner::standard(std::cout, affinity);
+        Banner::standard(std::cout, affinity, node_mask);
     }
 
     std::unique_ptr<GlobalSimplexMesh<DomainDimension>> globalMesh;


### PR DESCRIPTION
Add 3 lines  with build information to the banner, e.g.

```
                            Domain dimension 2
                            polynomial degree 2
                    Minimum order of quadrature rule 5
````
and worker affinity on node (to inspect how processes and threads are mapped to CPU cores, as done in SeisSol).
```
                          Worker affinity on node
    0123456789|012345----|----------|--23456789|01234567--|----------|
```
I think it can be useful e.g. to check the pinning of GPUs with CPUs.

Full log:
```
(base) ulrich@cachemiss:/export/dump/ulrich/tandem/examples/elasticity/2d$ mpirun -n 16 ../../../build2/app/static circular_hole.toml 

               ___          ___         _____         ___          ___
      ___     /  /\        /__/\       /  /::\       /  /\        /__/\
     /  /\   /  /::\       \  \:\     /  /:/\:\     /  /:/_      |  |::\
    /  /:/  /  /:/\:\       \  \:\   /  /:/  \:\   /  /:/ /\     |  |:|:\
   /  /:/  /  /:/~/::\  _____\__\:\ /__/:/ \__\:| /  /:/ /:/_  __|__|:|\:\
  /  /::\ /__/:/ /:/\:\/__/::::::::\\  \:\ /  /://__/:/ /:/ /\/__/::::| \:\
 /__/:/\:\\  \:\/:/__\/\  \:\~~\~~\/ \  \:\  /:/ \  \:\/:/ /:/\  \:\~~\__\/
 \__\/  \:\\  \::/      \  \:\  ~~~   \  \:\/:/   \  \::/ /:/  \  \:\
      \  \:\\  \:\       \  \:\        \  \::/     \  \:\/:/    \  \:\
       \__\/ \  \:\       \  \:\        \__\/       \  \::/      \  \:\
              \__\/        \__\/                     \__\/        \__\/

                      tandem version v1.0-69-ge53685e
                            Domain dimension 2
                            polynomial degree 2
                    Minimum order of quadrature rule 5

                       stack size limit = unlimited

                              Worker affinity
    0---------|----------|----------|----------|----------|----------|
    ----
                          Worker affinity on node
    0123456789|012345----|----------|--23456789|01234567--|----------|
    ----


DOFs: 9072
Mesh size: 0.131234
Assembly: 0.00266175 s
Solver warmup: 0.000809489 s
Solve: 0.0594655 s
Residual norm: 7.82003e-12
Iterations: 447
L2 error: 0.00336945
H1-semi error: 0.0577172

```