### PR TITLE
Allow friction law (ageing/slip) as a compile-time argument

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -51,6 +51,18 @@ add_custom_command(
         ${OPTIONS_FILE_NAME}
 )
 
+## Define options for state evolution law
+set(FRICTION_LAW "dieterich_ruina_ageing" CACHE STRING "Define the state variable evolution law")
+if (FRICTION_LAW STREQUAL "dieterich_ruina_ageing")
+    add_definitions(-DDR_AGEING_LAW)
+    message(STATUS "State evolution law: Dieterich-Ruina Ageing Law")
+elseif (FRICTION_LAW STREQUAL "dieterich_ruina_slip")
+    add_definitions(-DDR_SLIP_LAW)
+    message(STATUS "State evolution law: Dieterich-Ruina Slip Law")
+else()
+    message(FATAL_ERROR "Cannot recognize the given option. Your option should be either [dieterich_ruina_ageing] or [dieterich_ruina_slip].")
+endif()
+
 # Generate kernels
 
 if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.13)

--- a/app/localoperator/DieterichRuinaAgeing.h
+++ b/app/localoperator/DieterichRuinaAgeing.h
@@ -153,7 +153,7 @@ public:
         }
     }
 
-private:
+protected:
     double F(std::size_t index, double snAbs, double V, double psi) const {
         auto a = p_[index].get<A>();
         double e = exp(psi / a);

--- a/app/localoperator/DieterichRuinaSlip.h
+++ b/app/localoperator/DieterichRuinaSlip.h
@@ -1,0 +1,31 @@
+#ifndef DIETERICHRUINASLIP_20240131_H
+#define DIETERICHRUINASLIP_20240131_H
+
+#include "config.h"
+
+#include "geometry/Vector.h"
+#include "tensor/Tensor.h"
+#include "util/Zero.h"
+#include "localoperator/DieterichRuinaAgeing.h"
+
+#include "mneme/storage.hpp"
+
+#include <algorithm>
+#include <cassert>
+#include <cstddef>
+#include <exception>
+#include <iostream>
+
+namespace tndm {
+
+class DieterichRuinaSlip : public DieterichRuinaAgeing {
+public:
+    double state_rhs(std::size_t index, double V, double psi) const {
+        double myL = p_[index].get<L>();
+        return - cp_.b * V / myL * (log(V / cp_.V0) + (psi - cp_.f0) / cp_.b); // Slip law
+    }
+};
+
+} // namespace tndm
+
+#endif // DIETERICHRUINASLIP_20240131_H

--- a/app/localoperator/RateAndState.h
+++ b/app/localoperator/RateAndState.h
@@ -157,9 +157,9 @@ double RateAndState<Law>::rhs(double time, std::size_t faultNo,
     auto t_mat = traction_mat(traction);
     for (std::size_t node = 0; node < nbf; ++node) {
         auto sn = t_mat(node, 0);
-	if (delta_sn_) {
+        if (delta_sn_) {
             sn = sn + get_delta_sn(time, faultNo, node);
-	}
+        }
         auto psi = s_mat(node, PsiIndex);
         auto tau = get_tau(node, t_mat);
         if (delta_tau_) {
@@ -218,9 +218,9 @@ void RateAndState<Law>::state(double time, std::size_t faultNo,
     std::size_t index = faultNo * nbf;
     for (std::size_t node = 0; node < nbf; ++node) {
         auto sn = t_mat(node, 0);
-	if (delta_sn_) {
+        if (delta_sn_) {
             sn = sn + get_delta_sn(time, faultNo, node);
-	}
+        }
         auto tau = get_tau(node, t_mat);
         if (delta_tau_) {
             tau = tau + get_delta_tau(time, faultNo, node);

--- a/app/tandem/Context.h
+++ b/app/tandem/Context.h
@@ -8,6 +8,7 @@
 #include "form/FrictionOperator.h"
 #include "form/SeasQDOperator.h"
 #include "localoperator/DieterichRuinaAgeing.h"
+#include "localoperator/DieterichRuinaSlip.h"
 #include "localoperator/Elasticity.h"
 #include "localoperator/Poisson.h"
 #include "localoperator/RateAndState.h"
@@ -48,12 +49,16 @@ template <typename Type> class Context : public ContextBase {
 public:
     using adapter_t = AdapterOperator<Type>;
     using dg_t = DGOperator<Type>;
-    using friction_lop_t = RateAndState<DieterichRuinaAgeing>;
+    #if defined(DR_AGEING_LAW)
+        using friction_lop_t = RateAndState<DieterichRuinaAgeing>;
+    #elif defined(DR_SLIP_LAW)
+        using friction_lop_t = RateAndState<DieterichRuinaSlip>;
+    #endif
     using friction_t = FrictionOperator<friction_lop_t>;
 
     Context(LocalSimplexMesh<DomainDimension> const& mesh,
             std::unique_ptr<SeasScenario<Type>> seas_sc,
-            std::unique_ptr<DieterichRuinaAgeingScenario> friction_sc,
+            std::unique_ptr<DieterichRuinaScenario> friction_sc,
             std::array<double, DomainDimension> up, std::array<double, DomainDimension> ref_normal)
         : ContextBase(mesh, seas_sc->transform()), scenario(std::move(seas_sc)),
           friction_scenario(std::move(friction_sc)),
@@ -113,7 +118,7 @@ public:
     }
 
     std::unique_ptr<SeasScenario<Type>> scenario;
-    std::unique_ptr<DieterichRuinaAgeingScenario> friction_scenario;
+    std::unique_ptr<DieterichRuinaScenario> friction_scenario;
     std::shared_ptr<Type> dg_lop;
 
 private:

--- a/app/tandem/FrictionConfig.h
+++ b/app/tandem/FrictionConfig.h
@@ -3,6 +3,7 @@
 
 #include "config.h"
 #include "localoperator/DieterichRuinaAgeing.h"
+#include "localoperator/DieterichRuinaSlip.h"
 #include "localoperator/RateAndStateBase.h"
 #include "tandem/SeasSolution.h"
 
@@ -18,13 +19,13 @@
 
 namespace tndm {
 
-class DieterichRuinaAgeingScenario {
+class DieterichRuinaScenario {
 public:
     template <std::size_t D>
     using functional_t = std::function<std::array<double, 1>(std::array<double, D> const&)>;
     template <std::size_t D>
     using vector_functional_t =
-        std::function<std::array<double, DieterichRuinaAgeing::TangentialComponents>(
+        std::function<std::array<double, RateAndStateBase::TangentialComponents>(
             std::array<double, D> const&)>;
     static constexpr std::size_t NumQuantities = RateAndStateBase::NumQuantities;
 
@@ -43,7 +44,7 @@ public:
     constexpr static char DeltaSn[] = "delta_sn";
     constexpr static char FaultSolution[] = "fault_solution";
 
-    DieterichRuinaAgeingScenario(std::string const& lib, std::string const& scenario) {
+    DieterichRuinaScenario(std::string const& lib, std::string const& scenario) {
         lib_.loadFile(lib);
 
         a_ = lib_.getMemberFunction<DomainDimension, 1>(scenario, A);
@@ -54,15 +55,15 @@ public:
         }
         if (lib_.hasMember(scenario, TauPre)) {
             tau_pre_ =
-                lib_.getMemberFunction<DomainDimension, DieterichRuinaAgeing::TangentialComponents>(
+                lib_.getMemberFunction<DomainDimension, RateAndStateBase::TangentialComponents>(
                     scenario, TauPre);
         }
         Vinit_ =
-            lib_.getMemberFunction<DomainDimension, DieterichRuinaAgeing::TangentialComponents>(
+            lib_.getMemberFunction<DomainDimension, RateAndStateBase::TangentialComponents>(
                 scenario, Vinit);
         if (lib_.hasMember(scenario, Sinit)) {
             Sinit_ =
-                lib_.getMemberFunction<DomainDimension, DieterichRuinaAgeing::TangentialComponents>(
+                lib_.getMemberFunction<DomainDimension, RateAndStateBase::TangentialComponents>(
                     scenario, Sinit);
         }
         if (lib_.hasMember(scenario, Source)) {
@@ -72,7 +73,7 @@ public:
         if (lib_.hasMember(scenario, DeltaTau)) {
             delta_tau_ = std::make_optional(
                 lib_.getMemberFunction<DomainDimension + 1,
-                                       DieterichRuinaAgeing::TangentialComponents>(scenario,
+                                       RateAndStateBase::TangentialComponents>(scenario,
                                                                                    DeltaTau));
         }
         if (lib_.hasMember(scenario, DeltaSn)) {
@@ -126,10 +127,10 @@ protected:
     functional_t<DomainDimension> sn_pre_ =
         [](std::array<double, DomainDimension> const& x) -> std::array<double, 1> { return {0.0}; };
     vector_functional_t<DomainDimension> tau_pre_ = [](std::array<double, DomainDimension> const& x)
-        -> std::array<double, DieterichRuinaAgeing::TangentialComponents> { return {}; };
+        -> std::array<double, RateAndStateBase::TangentialComponents> { return {}; };
     vector_functional_t<DomainDimension> Vinit_;
     vector_functional_t<DomainDimension> Sinit_ = [](std::array<double, DomainDimension> const& x)
-        -> std::array<double, DieterichRuinaAgeing::TangentialComponents> { return {}; };
+        -> std::array<double, RateAndStateBase::TangentialComponents> { return {}; };
     std::optional<functional_t<DomainDimension + 1>> source_ = std::nullopt;
     std::optional<vector_functional_t<DomainDimension + 1>> delta_tau_ = std::nullopt;
     std::optional<functional_t<DomainDimension + 1>> delta_sn_ = std::nullopt;

--- a/app/tandem/SEAS.cpp
+++ b/app/tandem/SEAS.cpp
@@ -13,6 +13,7 @@
 #include "form/VolumeFunctionalFactory.h"
 #include "localoperator/Adapter.h"
 #include "localoperator/DieterichRuinaAgeing.h"
+#include "localoperator/DieterichRuinaSlip.h"
 #include "localoperator/Elasticity.h"
 #include "localoperator/Poisson.h"
 #include "localoperator/RateAndState.h"
@@ -53,7 +54,7 @@ template <typename Type>
 auto make_context(LocalSimplexMesh<DomainDimension> const& mesh, Config const& cfg) {
     return std::make_unique<seas::Context<Type>>(
         mesh, std::make_unique<SeasScenario<Type>>(cfg.lib, cfg.scenario),
-        std::make_unique<DieterichRuinaAgeingScenario>(cfg.lib, cfg.scenario), cfg.up,
+        std::make_unique<DieterichRuinaScenario>(cfg.lib, cfg.scenario), cfg.up,
         cfg.ref_normal);
 }
 


### PR DESCRIPTION
User can select their preferred friction law during compilation by setting an option `-DFRICTION_LAW` to be either `dieterich_ruina_ageing` or `dieterich_ruina_slip`. Default is `dieterich_ruina_ageing`.

Usage example:
`cmake $PATH_TO_TANDEM -DPOLYNOMIAL_DEGREE=6 -DDOMAIN_DIMENSION=2 -DFRICTION_LAW=dieterich_ruina_slip`

This PR is an extension from #65, which was built based on the `dmay/seas-checkpoint` branch. Also unified spelling to 'ageing' law, to appreciate the main developer's taste.