### PR TITLE
Clang warning fixes

### DIFF
--- a/app/tandem/Monitor.cpp
+++ b/app/tandem/Monitor.cpp
@@ -140,6 +140,9 @@ void MonitorFD::write_static() {
             writer->write_static(mneme::span(&data, 1));
             break;
         }
+        case DataLevel::BoundaryForMomentRate: {
+            break;
+        }
         };
     }
 }

--- a/app/tandem/Monitor.cpp
+++ b/app/tandem/Monitor.cpp
@@ -46,13 +46,13 @@ void MonitorQD::monitor(double time, BlockVector const& state) {
                     writer->write(time, mneme::span(&data, 1));
                     break;
                 }
-#ifdef ENABLE_HDF5
                 case DataLevel::BoundaryForMomentRate: {
+#ifdef ENABLE_HDF5
                     auto const& moment_rate = seasop_->friction().moment_rate_local();
                     writer->write(time, moment_rate);
+#endif
                     break;
                 }
-#endif
                 };
                 writer->increase_step(time, VMax);
             }
@@ -77,12 +77,12 @@ void MonitorQD::write_static() {
             writer->write_static(mneme::span(&data, 1));
             break;
         }
-#ifdef ENABLE_HDF5
         case DataLevel::BoundaryForMomentRate: {
+#ifdef ENABLE_HDF5
             writer->write_static();
+#endif
             break;
         }
-#endif
         };
     }
 }
@@ -109,13 +109,13 @@ void MonitorFD::monitor(double time, BlockVector const& v, BlockVector const& u,
                     writer->write(time, mneme::span(data.data(), 2));
                     break;
                 }
-#ifdef ENABLE_HDF5
                 case DataLevel::BoundaryForMomentRate: {
+#ifdef ENABLE_HDF5
                     auto const& moment_rate = seasop_->friction().moment_rate_local();
                     writer->write(time, moment_rate);
+#endif
                     break;
                 }
-#endif
                 };
                 writer->increase_step(time, VMax);
             }

--- a/app/tandem/SeasConfig.h
+++ b/app/tandem/SeasConfig.h
@@ -66,7 +66,8 @@ struct ProbeOutputConfig : OutputConfig {
         case TableWriterType::CSV:
             return std::make_unique<CSVWriter>();
         case TableWriterType::HDF5:
-            return nullptr; // HDF5ProbeWriter does not use TableWriter
+            throw std::logic_error(
+                "make_writer() called with HDF5 type - HDF5 output is dispatched separately");
         case TableWriterType::Unknown:
             throw std::logic_error("make_writer() called with Unknown type");
         }

--- a/app/tandem/SeasConfig.h
+++ b/app/tandem/SeasConfig.h
@@ -46,8 +46,10 @@ struct TabularOutputConfig : OutputConfig {
             return std::make_unique<TecplotWriter>();
         case TableWriterType::CSV:
             return std::make_unique<CSVWriter>();
+        case TableWriterType::HDF5:
+            return nullptr; // HDF5 tabular output handled separately (no TableWriter)
         case TableWriterType::Unknown:
-            return nullptr;
+            throw std::logic_error("make_writer() called with Unknown type");
         }
         return nullptr;
     }

--- a/app/tandem/Writer.h
+++ b/app/tandem/Writer.h
@@ -33,11 +33,8 @@ namespace tndm::seas {
 enum class DataLevel {
     Scalar,
     Boundary,
-    Volume
-#ifdef ENABLE_HDF5
-    ,
+    Volume,
     BoundaryForMomentRate // Fault surface data (moment rate) computed over fault area
-#endif
 };
 
 class Writer {

--- a/docker/release/Dockerfile.all
+++ b/docker/release/Dockerfile.all
@@ -29,6 +29,7 @@ RUN mkdir -p /tandem_main && \
                 -DCMAKE_PREFIX_PATH="${PETSC_INSTALL_DIR}" \
                 -DDOMAIN_DIMENSION=${DIM} \
                 -DPOLYNOMIAL_DEGREE=${DEG} \
+                -DENABLE_HDF5=OFF \
             && ninja \
             && cp app/tandem /tandem_main/tandem_${DIM}d_${DEG}p \
             && cp app/static /tandem_main/static_${DIM}d_${DEG}p; \

--- a/src/io/MeshParser.h
+++ b/src/io/MeshParser.h
@@ -20,6 +20,7 @@ public:
 
 class MeshParser {
 public:
+    virtual ~MeshParser() = default;
     static bool isGMSHFormat(std::string const& fileName);
     static bool isH5Format(std::string const& fileName);
     static std::unique_ptr<MeshParser> create(std::string const& fileName, MeshBuilder* builder);

--- a/src/io/MeshParser.h
+++ b/src/io/MeshParser.h
@@ -11,7 +11,7 @@ namespace tndm {
 
 class MeshBuilder {
 public:
-    virtual ~MeshBuilder() {}
+    virtual ~MeshBuilder() = default;
     virtual void setNumVertices(std::size_t numVertices) = 0;
     virtual void setVertex(long id, std::array<double, 3> const& x) = 0;
     virtual void setNumElements(std::size_t numElements) = 0;

--- a/src/io/MeshParser.h
+++ b/src/io/MeshParser.h
@@ -20,7 +20,6 @@ public:
 
 class MeshParser {
 public:
-    virtual ~MeshParser() = default;
     static bool isGMSHFormat(std::string const& fileName);
     static bool isH5Format(std::string const& fileName);
     static std::unique_ptr<MeshParser> create(std::string const& fileName, MeshBuilder* builder);
@@ -164,7 +163,7 @@ public:
     };
 
     MeshParser() = default;
-    ~MeshParser() = default;
+    virtual ~MeshParser() = default;
     virtual std::string_view getErrorMessage() const = 0;
     virtual bool parseFile(std::string const& fileName) = 0;
 };

--- a/test/HDF5Writer.cpp
+++ b/test/HDF5Writer.cpp
@@ -32,8 +32,8 @@ TEST_CASE("HDF5Writer - basic functionality") {
             std::vector<double> timestep0 = {0.1, 0.2, 0.3};
             std::vector<hsize_t> write_dims = {1, 3};
 
-            writer.writeToDataset(dset, H5T_NATIVE_DOUBLE, static_cast<hsize_t>(1e-3),
-                                  timestep0.data(), write_dims, glueDim, extensibleDim, false);
+            writer.writeToDataset(dset, H5T_NATIVE_DOUBLE, 0, timestep0.data(), write_dims, glueDim,
+                                  extensibleDim, false);
 
             std::vector<double> timestep1 = {1.1, 1.2, 1.3};
             writer.writeToDataset(dset, H5T_NATIVE_DOUBLE, 1, timestep1.data(), write_dims, glueDim,

--- a/test/HDF5Writer.cpp
+++ b/test/HDF5Writer.cpp
@@ -45,7 +45,9 @@ TEST_CASE("HDF5Writer - basic functionality") {
 
     SUBCASE("File exists after closing") {
         // Create and immediately destroy the writer so the file is flushed to disk
-        { HDF5Writer writer(filename, comm); }
+        {
+            HDF5Writer writer(filename, comm); 
+        }
 
         if (rank == 0) {
             CHECK(std::filesystem::exists(filename + ".h5"));

--- a/test/HDF5Writer.cpp
+++ b/test/HDF5Writer.cpp
@@ -46,7 +46,7 @@ TEST_CASE("HDF5Writer - basic functionality") {
     SUBCASE("File exists after closing") {
         // Create and immediately destroy the writer so the file is flushed to disk
         {
-            HDF5Writer writer(filename, comm); 
+            HDF5Writer writer(filename, comm);
         }
 
         if (rank == 0) {

--- a/test/HDF5Writer.cpp
+++ b/test/HDF5Writer.cpp
@@ -32,8 +32,8 @@ TEST_CASE("HDF5Writer - basic functionality") {
             std::vector<double> timestep0 = {0.1, 0.2, 0.3};
             std::vector<hsize_t> write_dims = {1, 3};
 
-            writer.writeToDataset(dset, H5T_NATIVE_DOUBLE, 1e-3, timestep0.data(), write_dims,
-                                  glueDim, extensibleDim, false);
+            writer.writeToDataset(dset, H5T_NATIVE_DOUBLE, static_cast<hsize_t>(1e-3),
+                                  timestep0.data(), write_dims, glueDim, extensibleDim, false);
 
             std::vector<double> timestep1 = {1.1, 1.2, 1.3};
             writer.writeToDataset(dset, H5T_NATIVE_DOUBLE, 1, timestep1.data(), write_dims, glueDim,
@@ -45,9 +45,7 @@ TEST_CASE("HDF5Writer - basic functionality") {
 
     SUBCASE("File exists after closing") {
         // Create and immediately destroy the writer so the file is flushed to disk
-        {
-            HDF5Writer writer(filename, comm);
-        }
+        { HDF5Writer writer(filename, comm); }
 
         if (rank == 0) {
             CHECK(std::filesystem::exists(filename + ".h5"));


### PR DESCRIPTION
Clang compiler produces some warnings 

```
/app/test/HDF5Writer.cpp:35:60: warning: implicit conversion from 'double' to 'hsize_t' (aka 'unsigned long long') changes value from 0.001 to 0 [-Wliteral-conversion]
   35 |             writer.writeToDataset(dset, H5T_NATIVE_DOUBLE, 1e-3, timestep0.data(), write_dims,
      |                    ~~~~~~~~~~~~~~                          ^~~~[9:09 AM]These ones would be also worth addressing
/app/app/tandem/Monitor.cpp:130:25: warning: enumeration value 'BoundaryForMomentRate' not handled in switch [-Wswitch]
  130 |         switch (writer->level()) {
      |                 ~~~~~~~~^~~~~~~
1 warning generated.
[100/162] Building CXX object app/CMakeFiles/tandem.dir/tandem/SeasConfig.cpp.o
In file included from /app/app/tandem/SeasConfig.cpp:1:
/app/app/tandem/SeasConfig.h:44:17: warning: enumeration value 'HDF5' not handled in switch [-Wswitch]
   44 |         switch (type) {
      |                 ^~~~
1 warning generated.
[101/162] Building CXX object app/CMakeFiles/tandem.dir/tandem.cpp.o
In file included from /app/app/tandem.cpp:8:
In file included from /app/app/tandem/SEAS.h:5:
/app/app/tandem/SeasConfig.h:44:17: warning: enumeration value 'HDF5' not handled in switch [-Wswitch]
   44 |         switch (type) {
      |                 ^~~~
1 warning generated.
[102/162] Building CXX object app/CMakeFiles/tandem.dir/tandem/SEAS.cpp.o
In file included from /app/app/tandem/SEAS.cpp:1:
In file included from /app/app/tandem/SEAS.h:5:
/app/app/tandem/SeasConfig.h:44:17: warning: enumeration value 'HDF5' not handled in switch [-Wswitch]
   44 |         switch (type) {
      |                 ^~~~
1 warning generated.
```
This PR fixes the warnings and gives a clean compilation. 